### PR TITLE
Testing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2020-06-05
+### Added
+- Name property added to appmap metadata
+- HTTP request parameters are captured
+- Spring path params are captured
+- Spring normalized path info is captured
+- Support for JUnit Jupiter
+
+### Fixed
+- Feature group metadata is now written to the correct key
+
 ## [0.0.2] - 2020-05-15
 ### Added
 - `language` object in `metadata` now includes `version` and `engine` based on
   the Java runtime.
 - `sql_query` events now include `database_type` as reported by the database
   driver.
+
 ## [0.0.1] - 2020-04-28
 ### Added
 - Versioning has begun. The authoritative `version` is now declared in

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.0.2'
+version = '0.1.0'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/src/main/java/com/appland/appmap/output/v1/HttpServerRequest.java
+++ b/src/main/java/com/appland/appmap/output/v1/HttpServerRequest.java
@@ -17,6 +17,9 @@ public class HttpServerRequest {
   @JSONField(name = "path_info")
   public String path;
 
+  @JSONField(name = "normalized_path_info")
+  public String normalizedPath;
+
   /**
    * Set the protocol of this request.
    * @param protocol The request protocol
@@ -47,6 +50,14 @@ public class HttpServerRequest {
    */
   public HttpServerRequest setPath(String path) {
     this.path = path;
+    return this;
+  }
+
+  /**
+   * Set the normalized path for this request.
+   */
+  public HttpServerRequest setNormalizedPath(String path) {
+    this.normalizedPath = path;
     return this;
   }
 }

--- a/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
+++ b/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
@@ -7,6 +7,8 @@ import com.appland.appmap.transform.annotations.HookClass;
 import com.appland.appmap.transform.annotations.MethodEvent;
 import com.appland.appmap.transform.annotations.Unique;
 
+import java.util.Map;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
@@ -29,6 +31,12 @@ public class HttpServerRequest {
 
     event.setHttpServerRequest(req.getMethod(), req.getRequestURI(), req.getProtocol());
     event.setParameters(null);
+
+    for (Map.Entry<String, String[]> param : req.getParameterMap().entrySet()) {
+      final String[] values = param.getValue();
+      event.addMessageParam(param.getKey(), values.length > 0 ? values[0] : "");
+    }
+
     recorder.add(event);
   }
 

--- a/src/main/java/com/appland/appmap/process/hooks/Message.java
+++ b/src/main/java/com/appland/appmap/process/hooks/Message.java
@@ -1,0 +1,43 @@
+package com.appland.appmap.process.hooks;
+
+import com.appland.appmap.output.v1.Event;
+import com.appland.appmap.record.Recorder;
+import com.appland.appmap.transform.annotations.CallbackOn;
+import com.appland.appmap.transform.annotations.ExcludeReceiver;
+import com.appland.appmap.transform.annotations.HookClass;
+import com.appland.appmap.transform.annotations.MethodEvent;
+
+import java.util.Map;
+
+
+/**
+ * Hooks to capture @{code message} data.
+ */
+public class Message {
+  private static final Recorder recorder = Recorder.getInstance();
+
+  /**
+   * Capture message params from Spring.
+   */
+  @CallbackOn(MethodEvent.METHOD_RETURN)
+  @ExcludeReceiver
+  @HookClass("org.springframework.util.PathMatcher")
+  public static void extractUriTemplateVariables(Event event,
+                                                 Object returnVal,
+                                                 String pattern,
+                                                 String path) {
+    final Event lastEvent = recorder.getLastEvent();
+    if (lastEvent == null) {
+      return;
+    }
+
+    if (lastEvent.httpRequest == null) {
+      return;
+    }
+
+    Map<String, String> pathParams = (Map<String, String>)returnVal;
+    for (Map.Entry<String, String> param : pathParams.entrySet()) {
+      lastEvent.addMessageParam(param.getKey(), param.getValue());
+    }
+  }
+}

--- a/src/main/java/com/appland/appmap/process/hooks/Message.java
+++ b/src/main/java/com/appland/appmap/process/hooks/Message.java
@@ -39,5 +39,7 @@ public class Message {
     for (Map.Entry<String, String> param : pathParams.entrySet()) {
       lastEvent.addMessageParam(param.getKey(), param.getValue());
     }
+    final String normalizedPath = pattern.replace('{', ':').replace("}", "");
+    lastEvent.httpRequest.setNormalizedPath(normalizedPath);
   }
 }

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -109,10 +109,7 @@ public class ToggleRecord {
     throw new ExitEarly();
   }
 
-  @ArgumentArray
-  @ExcludeReceiver
-  @HookAnnotated("org.junit.Test")
-  public static void startTest(Event event, Object[] args) {
+  private static void startTest(Event event) {
     try {
       final String fileName = String.join("_", event.definedClass, event.methodId)
           .replaceAll("[^a-zA-Z0-9-_]", "_");
@@ -147,15 +144,41 @@ public class ToggleRecord {
     }
   }
 
-  @ArgumentArray
-  @CallbackOn(MethodEvent.METHOD_RETURN)
-  @ExcludeReceiver
-  @HookAnnotated("org.junit.Test")
-  public static void stopTest(Event event, Object returnValue, Object[] args) {
+  private static void stopTest() {
     try {
       recorder.stop();
     } catch (ActiveSessionException e) {
       System.err.printf("AppMap: %s\n", e.getMessage());
     }
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @HookAnnotated("org.junit.Test")
+  public static void junit(Event event, Object[] args) {
+    startTest(event);
+  }
+
+  @ArgumentArray
+  @CallbackOn(MethodEvent.METHOD_RETURN)
+  @ExcludeReceiver
+  @HookAnnotated("org.junit.Test")
+  public static void junit(Event event, Object returnValue, Object[] args) {
+    stopTest();
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @HookAnnotated("org.junit.jupiter.api.Test")
+  public static void junitJupiter(Event event, Object[] args) {
+    startTest(event);
+  }
+
+  @ArgumentArray
+  @CallbackOn(MethodEvent.METHOD_RETURN)
+  @ExcludeReceiver
+  @HookAnnotated("org.junit.jupiter.api.Test")
+  public static void junitJupiter(Event event, Object returnValue, Object[] args) {
+    stopTest();
   }
 }

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -1,5 +1,6 @@
 package com.appland.appmap.process.hooks;
 
+import static com.appland.appmap.util.StringUtil.decapitalize;
 import static com.appland.appmap.util.StringUtil.identifierToSentence;
 
 import com.appland.appmap.output.v1.Event;
@@ -129,6 +130,10 @@ public class ToggleRecord {
 
       metadata.feature = identifierToSentence(event.methodId);
       metadata.featureGroup = identifierToSentence(event.definedClass);
+      metadata.scenarioName = String.format(
+        "%s %s",
+        metadata.featureGroup,
+        decapitalize(metadata.feature));
       metadata.recordedClassName = event.definedClass;
       metadata.recordedMethodName = event.methodId;
       if (junit) {

--- a/src/main/java/com/appland/appmap/record/AppMapSerializer.java
+++ b/src/main/java/com/appland/appmap/record/AppMapSerializer.java
@@ -101,7 +101,7 @@ public class AppMapSerializer {
       }
 
       if (metadata.featureGroup != null && !metadata.featureGroup.isEmpty()) {
-        this.json.writeKey("featureGroup");
+        this.json.writeKey("feature_group");
         this.json.writeValue(metadata.featureGroup);
       }
 

--- a/src/test/java/com/appland/appmap/record/RecorderTest.java
+++ b/src/test/java/com/appland/appmap/record/RecorderTest.java
@@ -1,0 +1,47 @@
+package com.appland.appmap.record;
+
+import static org.junit.Assert.assertEquals;
+
+import com.appland.appmap.output.v1.Event;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RecorderTest {
+
+  @Before
+  public void before() throws Exception {
+    final IRecordingSession.Metadata metadata =
+        new IRecordingSession.Metadata();
+
+    Recorder.getInstance().start(metadata);
+  }
+
+  @Test
+  public void testAllEventsWritten() {
+    final Recorder recorder = Recorder.getInstance();
+    final Long threadId = Thread.currentThread().getId();
+    final Event[] events = new Event[] {
+      new Event(),
+      new Event(),
+      new Event(),
+    };
+
+    for (int i = 0; i < events.length; i++) {
+      final Event event = events[i];
+      event
+          .setDefinedClass("SomeClass")
+          .setMethodId("SomeMethod")
+          .setThreadId(threadId);
+
+      recorder.add(event);
+      assertEquals(event, recorder.getLastEvent());
+    }
+
+    final String appmapJson = recorder.stop();
+    final String expectedJson = "\"thread_id\":" + threadId.toString();
+    final int numMatches = StringUtils.countMatches(appmapJson, expectedJson);
+    assertEquals(numMatches, events.length);
+  }
+}

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -47,5 +47,6 @@ COPY test/appmap.yml     /
 COPY test/entrypoint     /sbin/
 COPY test/*.bats         /test/
 COPY test/Props.java     /test/
+COPY test/helper.bash    /test/
 
 ENTRYPOINT ["/sbin/entrypoint"]

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+#
+# Helper methods for tests
+
+_curl() {
+  curl -H 'Accept: application/json' "${@}"
+}
+
+start_recording() {
+  _curl -sXPOST "${WS_URL}/_appmap/record"
+}
+
+stop_recording() {
+  output="$(_curl -sXDELETE ${WS_URL}/_appmap/record | tee /dev/stderr)"
+}
+
+teardown() {
+  stop_recording
+}
+
+print_debug() {
+  local query="${1}"
+  local result="${2}"
+
+  if [[ ! -z "${DEBUG_JSON}" ]]; then
+    echo "${output}" >&3
+    "result: ${result}" >&3
+  fi
+}
+
+assert_json() {
+  : "${output?}"
+
+  # Expect a jq query as $1. Pipe it into `select`, so null values
+  # will show up as a empty strings, rather than "null". (See
+  # discussion here: https://github.com/stedolan/jq/issues/24)
+  local query="${1?} | select(. == null | not)"
+  local result=$(jq -r "${query}" <<< "${output}")
+
+  print_debug "${query}" "${result}"
+  refute [ -z "${result}" ]
+}
+
+assert_json_eq() {
+  : "${output?}"
+
+  local query="${1?} | select(. == null | not)"
+  local expected_value="${2}"
+  local result=$(jq -r "${query}" <<< "${output}")
+
+  print_debug "${query}" "${result}"
+
+  assert [ "${result}" == "${expected_value}" ]
+}
+
+assert_json_contains() {
+  : "${output?}"
+
+  local query="${1?} | select(. == null | not)"
+  local match="${2}"
+  local result=$(jq -r "${query}" <<< "${output}")
+
+  print_debug "${query}" "${result}"
+  assert grep -q "${match}" <<< "${result}"
+}


### PR DESCRIPTION
Adds:
- Name property added to appmap metadata
- HTTP request parameters are captured
- Spring path params are captured
- Spring normalized path info is captured
- Support for JUnit Jupiter

Fixes:
- Feature group metadata is now written to the correct key

There's also an internal change which exposes the last event recorded so that it can be modified by a subsequent hook. See notes in commit fc54213.