### PR TITLE
Remove leaking dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-06-29
+### Added
+- Support for Jakarta
+
+### Removed
+- `javax.servlet` dependency
+
+### Changed
+- All logging is disabled by default. To enable logging use the `appmap.debug` system property.
+- Loading times have been reduced significantly.
+
 ## [0.1.0] - 2020-06-05
 ### Added
 - Name property added to appmap metadata

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ shadowJar {
   classifier = null
   minimize()
   dependencies {
-    // exclude(dependency('javax.servlet:javax.servlet-api:4.0.1'))
+    exclude(dependency('javax.servlet:javax.servlet-api:4.0.1'))
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.1.0'
+version = '0.2.0'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/src/main/java/com/appland/appmap/Agent.java
+++ b/src/main/java/com/appland/appmap/Agent.java
@@ -4,6 +4,7 @@ import com.appland.appmap.config.AppMapConfig;
 import com.appland.appmap.record.ActiveSessionException;
 import com.appland.appmap.record.Recorder;
 import com.appland.appmap.transform.ClassFileTransformer;
+import com.appland.appmap.util.Logger;
 
 import java.io.File;
 import java.lang.instrument.Instrumentation;
@@ -34,12 +35,12 @@ public class Agent {
       appmapPath = DEFAULT_CONFIG_FILE;
     }
 
-    System.err.printf("AppMap: agent loaded using config %s\n", appmapPath);
+    Logger.printf("AppMap: agent loaded using config %s\n", appmapPath);
 
     inst.addTransformer(new ClassFileTransformer());
 
     if (AppMapConfig.load(new File(appmapPath)) == null) {
-      System.err.printf("AppMap: failed to load config %s\n", appmapPath);
+      Logger.printf("AppMap: failed to load config %s\n", appmapPath);
       return;
     }
 

--- a/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -1,5 +1,7 @@
 package com.appland.appmap.config;
 
+import com.appland.appmap.util.Logger;
+
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
@@ -23,7 +25,7 @@ public class AppMapConfig {
     try {
       inputStream = new FileInputStream(configFile);
     } catch (FileNotFoundException e) {
-      System.err.println(String.format("error: file not found -> %s", configFile.getPath()));
+      Logger.println(String.format("error: file not found -> %s", configFile.getPath()));
       return null;
     }
 

--- a/src/main/java/com/appland/appmap/output/v1/CodeObject.java
+++ b/src/main/java/com/appland/appmap/output/v1/CodeObject.java
@@ -1,6 +1,9 @@
 package com.appland.appmap.output.v1;
 
 import com.alibaba.fastjson.annotation.JSONField;
+
+import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
 import javassist.CtClass;
 
@@ -153,7 +156,7 @@ public class CodeObject {
     CodeObject rootObject = CodeObject.createTree(packageName);
     CodeObject pkgLeafObject = rootObject.get(packageName);
     if (pkgLeafObject == null) {
-      System.err.println("failed to get leaf pkg object for package " + packageName);
+      Logger.println("failed to get leaf pkg object for package " + packageName);
       return null;
     }
 
@@ -176,7 +179,7 @@ public class CodeObject {
     CodeObject classObject = rootObject.get(classType.getName());
 
     if (classObject == null) {
-      System.err.println("failed to get class object for package " + classType.getPackageName());
+      Logger.println("failed to get class object for package " + classType.getPackageName());
       return null;
     }
 

--- a/src/main/java/com/appland/appmap/output/v1/Parameters.java
+++ b/src/main/java/com/appland/appmap/output/v1/Parameters.java
@@ -1,5 +1,7 @@
 package com.appland.appmap.output.v1;
 
+import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
 import javassist.CtClass;
 import javassist.NotFoundException;
@@ -54,7 +56,7 @@ public class Parameters implements Iterable<Value> {
     try {
       parameterTypes = behavior.getParameterTypes();
     } catch (NotFoundException e) {
-      System.err.println(
+      Logger.println(
           String.format("failed to get parameter types for %s.%s: %s",
               behavior.getDeclaringClass().getName(),
               behavior.getName(),

--- a/src/main/java/com/appland/appmap/output/v1/ParametersSerializer.java
+++ b/src/main/java/com/appland/appmap/output/v1/ParametersSerializer.java
@@ -3,6 +3,8 @@ package com.appland.appmap.output.v1;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.serializer.*;
 
+import com.appland.appmap.util.Logger;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
@@ -45,8 +47,8 @@ public class ParametersSerializer implements ObjectSerializer {
       Field valuesField = Parameters.class.getDeclaredField("values");
       out.write(JSON.toJSONString(valuesField.get(params)));
     } catch (Exception e) {
-      System.err.println("AppMap: failed to serialize parameters");
-      System.err.println(e.getMessage());
+      Logger.println("AppMap: failed to serialize parameters");
+      Logger.println(e.getMessage());
       out.writeNull();
     }
   }

--- a/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
+++ b/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
@@ -2,20 +2,16 @@ package com.appland.appmap.process.hooks;
 
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.record.Recorder;
+import com.appland.appmap.reflect.HttpServletRequest;
+import com.appland.appmap.reflect.HttpServletResponse;
+import com.appland.appmap.transform.annotations.ArgumentArray;
 import com.appland.appmap.transform.annotations.CallbackOn;
+import com.appland.appmap.transform.annotations.ExcludeReceiver;
 import com.appland.appmap.transform.annotations.HookClass;
 import com.appland.appmap.transform.annotations.MethodEvent;
 import com.appland.appmap.transform.annotations.Unique;
 
 import java.util.Map;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * Hooks to capture @{code http_server_request} and @{code http_server_response} data.
@@ -46,63 +42,103 @@ public class HttpServerRequest {
     recorder.add(event);
   }
 
+  @ArgumentArray
+  @ExcludeReceiver
   @HookClass("javax.servlet.Filter")
-  public static void doFilter(Event event,
-                              Filter self,
-                              ServletRequest req,
-                              ServletResponse res,
-                              FilterChain chain) {
-    recordHttpServerRequest(event, (HttpServletRequest) req);
+  public static void doFilter(Event event, Object[] args) {
+                              // Filter self,
+                              // ServletRequest req,
+                              // ServletResponse res,
+                              // FilterChain chain) {
+    if (args.length != 3) {
+      return;
+    }
+
+    HttpServletRequest req = new HttpServletRequest(args[0]);
+    recordHttpServerRequest(event, req);
   }
 
+  @ArgumentArray
+  @ExcludeReceiver
   @CallbackOn(MethodEvent.METHOD_RETURN)
   @HookClass("javax.servlet.Filter")
-  public static void doFilter(Event event,
-                              Filter self,
-                              Object returnValue,
-                              ServletRequest req,
-                              ServletResponse res,
-                              FilterChain chain) {
-    recordHttpServerResponse(event, (HttpServletResponse) res);
+  public static void doFilter(Event event, Object returnValue, Object[] args) {
+                              // Filter self,
+                              // Object returnValue,
+                              // ServletRequest req,
+                              // ServletResponse res,
+                              // FilterChain chain) {
+    if (args.length != 3) {
+      return;
+    }
+
+    HttpServletResponse res = new HttpServletResponse(args[1]);
+    recordHttpServerResponse(event, res);
   }
 
+  @ArgumentArray
+  @ExcludeReceiver
   @CallbackOn(MethodEvent.METHOD_EXCEPTION)
   @HookClass("javax.servlet.Filter")
-  public static void doFilter(Event event,
-                              Filter self,
-                              Exception exception,
-                              ServletRequest req,
-                              ServletResponse res,
-                              FilterChain chain) {
+  public static void doFilter(Event event, Exception exception, Object[] args) {
+                              // Filter self,
+                              // Exception exception,
+                              // ServletRequest req,
+                              // ServletResponse res,
+                              // FilterChain chain) {
+    if (args.length != 3) {
+      return;
+    }
+
     event.setException(exception);
     recorder.add(event);
   }
 
+  @ArgumentArray
+  @ExcludeReceiver
   @HookClass("javax.servlet.http.HttpServlet")
-  public static void service( Event event,
-                              HttpServlet self,
-                              HttpServletRequest req,
-                              HttpServletResponse res) {
+  public static void service( Event event, Object[] args) {
+                              // HttpServlet self,
+                              // HttpServletRequest req,
+                              // HttpServletResponse res) {
+    if (args.length != 2) {
+      return;
+    }
+
+    HttpServletRequest req = new HttpServletRequest(args[0]);
     recordHttpServerRequest(event, req);
   }
 
+  @ArgumentArray
+  @ExcludeReceiver
   @CallbackOn(MethodEvent.METHOD_RETURN)
   @HookClass("javax.servlet.http.HttpServlet")
-  public static void service( Event event,
-                              HttpServlet self,
-                              Object returnValue,
-                              HttpServletRequest req,
-                              HttpServletResponse res) {
+  public static void service( Event event, Object returnValue, Object[] args) {
+                              // HttpServlet self,
+                              // Object returnValue,
+                              // HttpServletRequest req,
+                              // HttpServletResponse res) {
+    if (args.length != 2) {
+      return;
+    }
+
+    HttpServletResponse res = new HttpServletResponse(args[1]);
     recordHttpServerResponse(event, res);
   }
 
+  @ArgumentArray
+  @ExcludeReceiver
   @CallbackOn(MethodEvent.METHOD_EXCEPTION)
   @HookClass("javax.servlet.http.HttpServlet")
-  public static void service( Event event,
-                              HttpServlet self,
-                              Exception exception,
-                              HttpServletRequest req,
-                              HttpServletResponse res) {
+  public static void service( Event event, Exception exception, Object[] args) {
+                              // HttpServlet self,
+                              // Exception exception,
+                              // HttpServletRequest req,
+                              // HttpServletResponse res) {
+    if (args.length != 2) {
+      return;
+    }
+
     event.setException(exception);
     recorder.add(event);
   }

--- a/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
+++ b/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
@@ -46,10 +46,18 @@ public class HttpServerRequest {
   @ExcludeReceiver
   @HookClass("javax.servlet.Filter")
   public static void doFilter(Event event, Object[] args) {
-                              // Filter self,
-                              // ServletRequest req,
-                              // ServletResponse res,
-                              // FilterChain chain) {
+    if (args.length != 3) {
+      return;
+    }
+
+    HttpServletRequest req = new HttpServletRequest(args[0]);
+    recordHttpServerRequest(event, req);
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @HookClass(value = "jakarta.servlet.Filter", method = "doFilter")
+  public static void doFilterJakarta(Event event, Object[] args) {
     if (args.length != 3) {
       return;
     }
@@ -63,11 +71,19 @@ public class HttpServerRequest {
   @CallbackOn(MethodEvent.METHOD_RETURN)
   @HookClass("javax.servlet.Filter")
   public static void doFilter(Event event, Object returnValue, Object[] args) {
-                              // Filter self,
-                              // Object returnValue,
-                              // ServletRequest req,
-                              // ServletResponse res,
-                              // FilterChain chain) {
+    if (args.length != 3) {
+      return;
+    }
+
+    HttpServletResponse res = new HttpServletResponse(args[1]);
+    recordHttpServerResponse(event, res);
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @CallbackOn(MethodEvent.METHOD_RETURN)
+  @HookClass(value = "jakarta.servlet.Filter", method = "doFilter")
+  public static void doFilterJakarta(Event event, Object returnValue, Object[] args) {
     if (args.length != 3) {
       return;
     }
@@ -81,11 +97,19 @@ public class HttpServerRequest {
   @CallbackOn(MethodEvent.METHOD_EXCEPTION)
   @HookClass("javax.servlet.Filter")
   public static void doFilter(Event event, Exception exception, Object[] args) {
-                              // Filter self,
-                              // Exception exception,
-                              // ServletRequest req,
-                              // ServletResponse res,
-                              // FilterChain chain) {
+    if (args.length != 3) {
+      return;
+    }
+
+    event.setException(exception);
+    recorder.add(event);
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @CallbackOn(MethodEvent.METHOD_EXCEPTION)
+  @HookClass(value = "jakarta.servlet.Filter", method = "doFilter")
+  public static void doFilterJakarta(Event event, Exception exception, Object[] args) {
     if (args.length != 3) {
       return;
     }
@@ -98,9 +122,18 @@ public class HttpServerRequest {
   @ExcludeReceiver
   @HookClass("javax.servlet.http.HttpServlet")
   public static void service( Event event, Object[] args) {
-                              // HttpServlet self,
-                              // HttpServletRequest req,
-                              // HttpServletResponse res) {
+    if (args.length != 2) {
+      return;
+    }
+
+    HttpServletRequest req = new HttpServletRequest(args[0]);
+    recordHttpServerRequest(event, req);
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @HookClass(value = "jakarta.servlet.http.HttpServlet", method = "service")
+  public static void serviceJakarta( Event event, Object[] args) {
     if (args.length != 2) {
       return;
     }
@@ -113,11 +146,20 @@ public class HttpServerRequest {
   @ExcludeReceiver
   @CallbackOn(MethodEvent.METHOD_RETURN)
   @HookClass("javax.servlet.http.HttpServlet")
-  public static void service( Event event, Object returnValue, Object[] args) {
-                              // HttpServlet self,
-                              // Object returnValue,
-                              // HttpServletRequest req,
-                              // HttpServletResponse res) {
+  public static void service(Event event, Object returnValue, Object[] args) {
+    if (args.length != 2) {
+      return;
+    }
+
+    HttpServletResponse res = new HttpServletResponse(args[1]);
+    recordHttpServerResponse(event, res);
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @CallbackOn(MethodEvent.METHOD_RETURN)
+  @HookClass(value = "jakarta.servlet.http.HttpServlet", method = "service")
+  public static void serviceJakarta(Event event, Object returnValue, Object[] args) {
     if (args.length != 2) {
       return;
     }
@@ -131,10 +173,19 @@ public class HttpServerRequest {
   @CallbackOn(MethodEvent.METHOD_EXCEPTION)
   @HookClass("javax.servlet.http.HttpServlet")
   public static void service( Event event, Exception exception, Object[] args) {
-                              // HttpServlet self,
-                              // Exception exception,
-                              // HttpServletRequest req,
-                              // HttpServletResponse res) {
+    if (args.length != 2) {
+      return;
+    }
+
+    event.setException(exception);
+    recorder.add(event);
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @CallbackOn(MethodEvent.METHOD_EXCEPTION)
+  @HookClass(value = "jakarta.servlet.http.HttpServlet", method = "service")
+  public static void serviceJakarta( Event event, Exception exception, Object[] args) {
     if (args.length != 2) {
       return;
     }

--- a/src/main/java/com/appland/appmap/process/hooks/SqlQuery.java
+++ b/src/main/java/com/appland/appmap/process/hooks/SqlQuery.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.record.Recorder;
 import com.appland.appmap.transform.annotations.*;
+import com.appland.appmap.util.Logger;
 
 /**
  * Hooks to capture {@code sql_query} data from classes included in configuration.
@@ -31,7 +32,7 @@ public class SqlQuery {
       dbname = c.getMetaData().getDatabaseProductName();
     }
     catch (SQLException e) {
-      System.err.println("WARNING, failed to get database name");
+      Logger.println("WARNING, failed to get database name");
       e.printStackTrace(System.err);
     }
     return dbname;
@@ -43,7 +44,7 @@ public class SqlQuery {
       dbname = getDbName(s.getConnection());
     }
     catch (SQLException e) {
-      System.err.println("WARNING, failed to get statement's connection");
+      Logger.println("WARNING, failed to get statement's connection");
       e.printStackTrace(System.err);
     }
     return dbname;

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -12,6 +12,7 @@ import com.appland.appmap.reflect.HttpServletRequest;
 import com.appland.appmap.reflect.HttpServletResponse;
 import com.appland.appmap.reflect.FilterChain;
 import com.appland.appmap.transform.annotations.*;
+import com.appland.appmap.util.Logger;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -35,7 +36,7 @@ public class ToggleRecord {
     } catch (ActiveSessionException e) {
       res.setStatus(HttpServletResponse.SC_NOT_FOUND);
     } catch (IOException e) {
-      System.err.printf("failed to write response: %s\n", e.getMessage());
+      Logger.printf("failed to write response: %s\n", e.getMessage());
     }
   }
 
@@ -51,7 +52,7 @@ public class ToggleRecord {
       writer.write(responseJson);
       writer.flush();
     } catch (IOException e) {
-      System.err.printf("failed to write response: %s\n", e.getMessage());
+      Logger.printf("failed to write response: %s\n", e.getMessage());
     }
   }
 
@@ -147,7 +148,7 @@ public class ToggleRecord {
 
       recorder.start(fileName, metadata);
     } catch (ActiveSessionException e) {
-      System.err.printf("AppMap: %s\n", e.getMessage());
+      Logger.printf("AppMap: %s\n", e.getMessage());
     }
   }
 
@@ -155,7 +156,7 @@ public class ToggleRecord {
     try {
       recorder.stop();
     } catch (ActiveSessionException e) {
-      System.err.printf("AppMap: %s\n", e.getMessage());
+      Logger.printf("AppMap: %s\n", e.getMessage());
     }
   }
 

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.appland.appmap.output.v1.CodeObject;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.process.ThreadLock;
+import com.appland.appmap.util.Logger;
 
 /**
  * Recorder is a singleton responsible for managing recording sessions and routing events to any
@@ -41,7 +42,7 @@ public class Recorder {
     try {
       this.activeSession.start();
     } catch (ActiveSessionException e) {
-      System.err.printf("AppMap: failed to start recording\n%s\n", e.getMessage());
+      Logger.printf("AppMap: failed to start recording\n%s\n", e.getMessage());
       this.stop();
     }
   }
@@ -109,7 +110,7 @@ public class Recorder {
     try {
       this.writeEvent(pendingEvent);
     } catch (ActiveSessionException e) {
-      System.err.printf("AppMap: failed to record event\n%s\n", e.getMessage());
+      Logger.printf("AppMap: failed to record event\n%s\n", e.getMessage());
       this.queuedEvents.remove(threadId);
       this.activeSession.stop();
     }
@@ -127,7 +128,7 @@ public class Recorder {
         this.writeEvent(event);
       }
     } catch (ActiveSessionException e) {
-      System.err.printf("AppMap: failed to record event\n%s\n", e.getMessage());
+      Logger.printf("AppMap: failed to record event\n%s\n", e.getMessage());
       this.queuedEvents.clear();
       this.activeSession.stop();
     }
@@ -166,7 +167,7 @@ public class Recorder {
       processorStack.lock();
       output = this.activeSession.stop();
     } catch (ActiveSessionException e) {
-      System.err.printf("AppMap: failed to stop recording\n%s\n", e.getMessage());
+      Logger.printf("AppMap: failed to stop recording\n%s\n", e.getMessage());
     } finally {
       processorStack.unlock();
       processorStack.exit();
@@ -197,7 +198,7 @@ public class Recorder {
     try {
       this.activeSession.add(codeObject);
     } catch (ActiveSessionException e) {
-      System.err.printf("AppMap: failed to record code object\n%s\n", e.getMessage());
+      Logger.printf("AppMap: failed to record code object\n%s\n", e.getMessage());
       this.activeSession.stop();
     }
   }

--- a/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
@@ -1,6 +1,7 @@
 package com.appland.appmap.record;
 
 import com.appland.appmap.output.v1.Event;
+import com.appland.appmap.util.Logger;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -94,7 +95,7 @@ public class RecordingSessionFileStream extends RecordingSessionGeneric {
       );
     }
 
-    System.err.printf("AppMap: wrote %s\n", this.fileName);
+    Logger.printf("AppMap: wrote %s\n", this.fileName);
 
     return "";
   }

--- a/src/main/java/com/appland/appmap/reflect/FilterChain.java
+++ b/src/main/java/com/appland/appmap/reflect/FilterChain.java
@@ -1,0 +1,29 @@
+package com.appland.appmap.reflect;
+
+import java.lang.reflect.Method;
+
+import com.appland.appmap.util.Logger;
+
+public class FilterChain extends ReflectiveType {
+  private static Method fnDoFilter;
+
+  public FilterChain(Object self) {
+    super(self);
+
+    if (fnDoFilter == null) {
+      fnDoFilter = this.getMethod("doFilter",
+          "javax.servlet.ServletRequest",
+          "javax.servlet.ServletResponse");
+    }
+  }
+
+  public void doFilter(Object request, Object response) {
+    if (fnDoFilter != null) {
+      try {
+        fnDoFilter.invoke(this.self, request, response);
+      } catch (Exception e) {
+        Logger.printf("failed to invoke method doFilter: %s", e.getMessage());
+      }
+    }
+  }
+}

--- a/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
+++ b/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
@@ -1,0 +1,96 @@
+package com.appland.appmap.reflect;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.HashMap;
+
+public class HttpServletRequest extends ReflectiveType {
+  private static Method fnGetMethod;
+  private static Method fnGetRequestURI;
+  private static Method fnGetProtocol;
+  private static Method fnGetParameterMap;
+
+  public HttpServletRequest(Object self) {
+    super(self);
+
+    if (fnGetMethod == null) {
+      try {
+        fnGetMethod = this.self.getClass().getMethod("getMethod");
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnGetRequestURI == null) {
+      try {
+        fnGetRequestURI = this.self.getClass().getMethod("getRequestURI");
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnGetProtocol == null) {
+      try {
+        fnGetProtocol = this.self.getClass().getMethod("getProtocol");
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnGetParameterMap == null) {
+      try {
+        fnGetParameterMap = this.self.getClass().getMethod("getParameterMap");
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+  }
+
+  public String getMethod() {
+    if (fnGetMethod != null) {
+      try {
+        return (String) fnGetMethod.invoke(this.self);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    return "";
+  }
+
+  public String getRequestURI() {
+    if (fnGetRequestURI != null) {
+      try {
+        return (String) fnGetRequestURI.invoke(this.self);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    return "";
+  }
+
+  public String getProtocol() {
+    if (fnGetProtocol != null) {
+      try {
+        return (String) fnGetProtocol.invoke(this.self);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    return "";
+  }
+
+  public Map<String, String[]> getParameterMap() {
+    if (fnGetProtocol != null) {
+      try {
+        return (Map<String, String[]>) fnGetParameterMap.invoke(this.self);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    return new HashMap<String, String[]>();
+  }
+}

--- a/src/main/java/com/appland/appmap/reflect/HttpServletResponse.java
+++ b/src/main/java/com/appland/appmap/reflect/HttpServletResponse.java
@@ -1,0 +1,136 @@
+package com.appland.appmap.reflect;
+
+import java.io.PrintWriter;
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+public class HttpServletResponse extends ReflectiveType {
+  public static final int SC_CONFLICT = 409;
+  public static final int SC_NOT_FOUND = 404;
+  public static final int SC_OK = 200;
+
+  private static Method fnSetContentType;
+  private static Method fnSetContentLength;
+  private static Method fnSetStatus;
+  private static Method fnGetWriter;
+  private static Method fnGetStatus;
+  private static Method fnGetContentType;
+
+  public HttpServletResponse(Object self) {
+    super(self);
+
+    if (fnSetContentType == null) {
+      try {
+        fnSetContentType = this.self.getClass().getMethod("setContentType", String.class);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnSetContentLength == null) {
+      try {
+        fnSetContentLength = this.self.getClass().getMethod("setContentLength", int.class);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnSetStatus == null) {
+      try {
+        fnSetStatus = this.self.getClass().getMethod("setStatus", int.class);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnGetWriter == null) {
+      try {
+        fnGetWriter = this.self.getClass().getMethod("getWriter");
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnGetStatus == null) {
+      try {
+        fnGetStatus = this.self.getClass().getMethod("getStatus");
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    if (fnGetContentType == null) {
+      try {
+        fnGetContentType = this.self.getClass().getMethod("getContentType");
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+  }
+
+  public void setContentType(String type) {
+    if (fnSetContentType != null) {
+      try {
+        fnSetContentType.invoke(this.self, type);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+  }
+
+  public void setContentLength(int len) {
+    if (fnSetContentLength != null) {
+      try {
+        fnSetContentLength.invoke(this.self, len);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+  }
+
+  public void setStatus(int sc) {
+    if (fnSetStatus != null) {
+      try {
+        fnSetStatus.invoke(this.self, sc);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+  }
+
+  public PrintWriter getWriter() throws IOException {
+    if (fnGetWriter != null) {
+      try {
+        return (PrintWriter) fnGetWriter.invoke(this.self);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    return null;
+  }
+
+  public int getStatus() {
+    if (fnGetStatus != null) {
+      try {
+        return (int) fnGetStatus.invoke(this.self);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    return -1;
+  }
+
+  public String getContentType() {
+    if (fnGetContentType != null) {
+      try {
+        return (String) fnGetContentType.invoke(this.self);
+      } catch (Exception e) {
+        /* log an error */
+      }
+    }
+
+    return "";
+  }
+}

--- a/src/main/java/com/appland/appmap/reflect/ReflectiveType.java
+++ b/src/main/java/com/appland/appmap/reflect/ReflectiveType.java
@@ -1,0 +1,71 @@
+package com.appland.appmap.reflect;
+
+import java.lang.reflect.Method;
+
+import com.appland.appmap.util.Logger;
+
+public class ReflectiveType {
+  protected Object self;
+
+  public ReflectiveType(Object self) {
+    this.self = self;
+  }
+
+  public Object GetObject() {
+    return this.self;
+  }
+
+  protected Method getMethod(String name, Class<?>... parameterTypes) {
+    try {
+      return this.self.getClass().getMethod(name, parameterTypes);
+    } catch (Exception e) {
+      Logger.printf("failed to get method %s: %s\n", name, e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Looks up a method signature by class names.
+   * @param name Method name
+   * @param parameterTypes Fully qualified class names of all parameters
+   * @return Matching method if found. Otherwise, null.
+   */
+  protected Method getMethod(String name, String... parameterTypes) {
+    Method[] methods;
+
+    try {
+      methods = this.self.getClass().getMethods();
+    } catch (Exception e) {
+      Logger.printf("failed to get method %s: %s\n", name, e.getMessage());
+      return null;
+    }
+
+    for (Method method : methods) {
+      if (!method.getName().equals(name)) {
+        continue;
+      }
+
+      final Class<?>[] methodParamTypes = method.getParameterTypes();
+      if (methodParamTypes.length != parameterTypes.length) {
+        continue;
+      }
+
+      boolean match = true;
+      for (int i = 0; i < methodParamTypes.length; i++) {
+        final String a = methodParamTypes[i].getName();
+        final String b = parameterTypes[i];
+
+        if (!a.equals(b)) {
+          match = false;
+          break;
+        }
+      }
+
+      if (match) {
+        return method;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -142,7 +142,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
                           Class redefiningClass,
                           ProtectionDomain domain,
                           byte[] bytes) throws IllegalClassFormatException {
-    ClassPool classPool = ClassPool.getDefault();
+    ClassPool classPool = new ClassPool(true);
     classPool.appendClassPath(new LoaderClassPath(loader));
 
     try {

--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -4,6 +4,7 @@ import com.appland.appmap.output.v1.NoSourceAvailableException;
 import com.appland.appmap.transform.annotations.Hook;
 import com.appland.appmap.transform.annotations.HookSite;
 import com.appland.appmap.transform.annotations.HookValidationException;
+import com.appland.appmap.util.Logger;
 import javassist.*;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
@@ -28,7 +29,6 @@ import java.util.stream.Stream;
  * hooks to each behavior declared by that class.
  */
 public class ClassFileTransformer implements java.lang.instrument.ClassFileTransformer {
-  private static final Boolean debug = (System.getProperty("appmap.debug") != null);
   private static final List<Hook> unkeyedHooks = new ArrayList<Hook>();
   private static final HashMap<String, List<Hook>> keyedHooks = new HashMap<String, List<Hook>>();
 
@@ -48,8 +48,8 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
         CtClass ctClass = classPool.get(classType.getName());
         processClass(ctClass);
       } catch (NotFoundException e) {
-        System.err.printf("AppMap: failed to find %s in class pool", classType.getName());
-        System.err.println(e.getMessage());
+        Logger.printf("AppMap: failed to find %s in class pool", classType.getName());
+        Logger.println(e.getMessage());
       }
     } 
   }
@@ -60,7 +60,9 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
     }
 
     String key = hook.getKey();
-    System.err.printf("%s: %s\n", key, hook);
+
+    Logger.printf("%s: %s\n", key, hook);
+
     if (key == null) {
       unkeyedHooks.add(hook);
     } else {
@@ -96,16 +98,14 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
       try {
         hook.validate();
       } catch (HookValidationException e) {
-        System.err.println("AppMap: failed to validate hook");
-        System.err.println(e.getMessage());
+        Logger.println("AppMap: failed to validate hook");
+        Logger.println(e.getMessage());
         continue;
       }
 
       this.addHook(hook);
 
-      if (debug) {
-        System.out.printf("AppMap: registered hook %s\n", hook.toString());
-      }
+      Logger.printf("AppMap: registered hook %s\n", hook.toString());
     }
   }
 
@@ -123,15 +123,13 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
 
       Hook.apply(behavior, hookSites);
 
-      if (debug) {
-        for (HookSite hookSite : hookSites) {
-          final Hook hook = hookSite.getHook();
-          System.err.printf("AppMap: hooked %s.%s (%s) with %s\n",
-                behavior.getDeclaringClass().getName(),
-                behavior.getName(),
-                hook.getMethodEvent().getEventString(),
-                hook);
-        }
+      for (HookSite hookSite : hookSites) {
+        final Hook hook = hookSite.getHook();
+        Logger.printf("AppMap: hooked %s.%s (%s) with %s\n",
+              behavior.getDeclaringClass().getName(),
+              behavior.getName(),
+              hook.getMethodEvent().getEventString(),
+              hook);
       }
     } catch (NoSourceAvailableException e) {
       return;
@@ -181,8 +179,8 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
     } catch (Exception e) {
       // Don't allow this exception to propagate out of this method, because it will be swallowed
       // by sun.instrument.TransformerManager.
-      System.err.println("An error occurred transforming class " + className);
-      System.err.println(e.getClass() + ": " + e.getMessage());
+      Logger.println("An error occurred transforming class " + className);
+      Logger.println(e.getClass() + ": " + e.getMessage());
       e.printStackTrace(System.err);
     }
 

--- a/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
@@ -2,6 +2,8 @@ package com.appland.appmap.transform.annotations;
 
 import com.appland.appmap.output.v1.Parameters;
 import com.appland.appmap.output.v1.Value;
+import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
 import javassist.CtClass;
 import javassist.CtMethod;
@@ -51,8 +53,8 @@ public class CallbackOnSystem extends BaseSystem {
 
           runtimeParameters.add(returnValue);
         } catch (NotFoundException e) {
-          System.err.println("AppMap: warning - unknown return type");
-          System.err.println(e.getMessage());
+          Logger.println("AppMap: warning - unknown return type");
+          Logger.println(e.getMessage());
         }
       }
     } else if (this.methodEvent == MethodEvent.METHOD_EXCEPTION) {

--- a/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
@@ -1,5 +1,7 @@
 package com.appland.appmap.transform.annotations;
 
+import com.appland.appmap.util.Logger;
+
 import javassist.CtClass;
 import javassist.NotFoundException;
 
@@ -39,8 +41,8 @@ class CtClassUtil {
         superClass = superClass.getSuperclass();
       }
     } catch (NotFoundException e) {
-      System.err.println("AppMap: could not resolve class hierarchy");
-      System.err.println(e.getMessage());
+      Logger.println("AppMap: could not resolve class hierarchy");
+      Logger.println(e.getMessage());
     }
 
     return false;

--- a/src/main/java/com/appland/appmap/transform/annotations/Hook.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/Hook.java
@@ -2,6 +2,7 @@ package com.appland.appmap.transform.annotations;
 
 import com.appland.appmap.output.v1.Parameters;
 import com.appland.appmap.record.EventTemplateRegistry;
+import com.appland.appmap.util.Logger;
 import javassist.*;
 
 import java.util.ArrayList;
@@ -75,7 +76,7 @@ public class Hook {
     Hook hook = new Hook(sourceSystem, optionalSystems, hookBehavior);
     for (ISystem optionalSystem : optionalSystems) {
       if (!optionalSystem.validate(hook)) {
-        System.err.println("AppMap: hook "
+        Logger.println("AppMap: hook "
             + hook
             + " failed validation from "
             + optionalSystem.getClass().getSimpleName());
@@ -187,16 +188,16 @@ public class Hook {
           ClassPool.getDefault().get("java.lang.Exception"));
       
     } catch (CannotCompileException e) {
-      System.err.println("AppMap: failed to compile");
-      System.err.println("        method "
+      Logger.println("AppMap: failed to compile");
+      Logger.println("        method "
           + targetBehavior.getDeclaringClass().getName()
           + "."
           + targetBehavior.getName());
 
-      System.err.println(e.getMessage());
+      Logger.println(e.getMessage());
     } catch (NotFoundException e) {
-      System.err.println("AppMap: failed to find class\n");
-      System.err.println(e.getMessage());
+      Logger.println("AppMap: failed to find class\n");
+      Logger.println(e.getMessage());
     }
   }
 
@@ -283,8 +284,8 @@ public class Hook {
       try {
         returnType = ((CtMethod) behavior).getReturnType();
       } catch (NotFoundException e) {
-        System.err.println("AppMap: warning - unknown return type");
-        System.err.println(e.getMessage());
+        Logger.println("AppMap: warning - unknown return type");
+        Logger.println(e.getMessage());
       }
     }
     return returnType;

--- a/src/main/java/com/appland/appmap/transform/annotations/HookAnnotatedSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookAnnotatedSystem.java
@@ -1,5 +1,7 @@
 package com.appland.appmap.transform.annotations;
 
+import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
 
 public class HookAnnotatedSystem extends SourceMethodSystem {
@@ -28,7 +30,7 @@ public class HookAnnotatedSystem extends SourceMethodSystem {
   @Override
   public Boolean match(CtBehavior behavior) {
     if (behavior.hasAnnotation(this.annotationClass)) {
-      System.err.println("!!");
+      Logger.println("!!");
     }
     return behavior.hasAnnotation(this.annotationClass);
   }

--- a/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
@@ -1,5 +1,7 @@
 package com.appland.appmap.transform.annotations;
 
+import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
 
 public class HookClassSystem extends SourceMethodSystem {
@@ -46,7 +48,7 @@ public class HookClassSystem extends SourceMethodSystem {
 
       return system;
     } catch (Exception e) {
-      System.err.println(e);
+      Logger.println(e);
       return null;
     }
   }

--- a/src/main/java/com/appland/appmap/transform/annotations/HookConditionSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookConditionSystem.java
@@ -1,6 +1,8 @@
 package com.appland.appmap.transform.annotations;
 
 import com.appland.appmap.process.conditions.Condition;
+import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
 
 import java.lang.reflect.Method;
@@ -54,8 +56,8 @@ public class HookConditionSystem extends SourceMethodSystem {
     try {
       return (Boolean) this.conditionMethod.invoke(null, behavior);
     } catch (Exception e) {
-      System.err.printf("AppMap: match failed due to %s exception\n", e.getClass().getName());
-      System.err.println(e.getMessage());
+      Logger.printf("AppMap: match failed due to %s exception\n", e.getClass().getName());
+      Logger.println(e.getMessage());
       return false;
     }
   }

--- a/src/main/java/com/appland/appmap/util/Logger.java
+++ b/src/main/java/com/appland/appmap/util/Logger.java
@@ -1,0 +1,25 @@
+package com.appland.appmap.util;
+
+public class Logger {
+  private static final Boolean debug = (System.getProperty("appmap.debug") != null);
+
+  public static void println(Exception e) {
+    Logger.println(e.getMessage());
+  }
+
+  public static void println(String msg) {
+    if (!debug) {
+      return;
+    }
+
+    System.err.println("AppMap [DEBUG]: " + msg);
+  }
+
+  public static void printf(String format, Object... args) {
+    if (!debug) {
+      return;
+    }
+
+    System.err.printf("AppMap [DEBUG]: " + format, args);
+  }
+}

--- a/src/main/java/com/appland/appmap/web/RecordServlet.java
+++ b/src/main/java/com/appland/appmap/web/RecordServlet.java
@@ -3,6 +3,7 @@ package com.appland.appmap.web;
 import com.appland.appmap.record.ActiveSessionException;
 import com.appland.appmap.record.IRecordingSession;
 import com.appland.appmap.record.Recorder;
+import com.appland.appmap.util.Logger;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -28,7 +29,7 @@ public class RecordServlet extends HttpServlet {
     } catch (ActiveSessionException e) {
       res.setStatus(HttpServletResponse.SC_NOT_FOUND);
     } catch (IOException e) {
-      System.err.printf("failed to write response: %s\n", e.getMessage());
+      Logger.printf("failed to write response: %s\n", e.getMessage());
     }
   }
 
@@ -45,7 +46,7 @@ public class RecordServlet extends HttpServlet {
       writer.write(responseJson);
       writer.flush();
     } catch (IOException e) {
-      System.err.printf("failed to write response: %s\n", e.getMessage());
+      Logger.printf("failed to write response: %s\n", e.getMessage());
     }
   }
 


### PR DESCRIPTION
- `javax.servlet` was being bundled by our JAR and potentially loaded by host applications. The dependency was removed and the issue has been resolved.
- Servlet hooks now use reflection as a result.
- Logging is now fully silenced unless `appmap.debug` is present.
- Added support for Jakarta. This means we'll be able to hook more recent versions of Tomcat.