### PR TITLE
Jenkins testing enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Ignore Gradle build output directory
 build
 
+# Appmap files
+tmp
+
 .classpath
 .project
 .settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
   - "$HOME/.gradle/wrapper/"
 script:
 - ./gradlew check -s
+- ./gradlew integrationTest
 - ./bin/test
 deploy:
   provider: releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2020-07-08
+### Fixed
+- Removed a potential deadlock that could occur if the user's code required a lock in `toString`.
+- Output directories will be recursively created
+
+### Added
+- `appmap.event.valueSize` can be used to specify the length of a value string before truncation
+  occurs.
+- `Recorder.record` will record and output the execution of a `Runnable`.
+
+### Changed
+- In `appmap.yml` a package item can now have an empty `path`, allowing the user to specify
+  a list of exclusions only. This can be useful for excluding groups of tests not meant to
+  be captured.
+- The default output directory for appmap files is now `./appmap`. This directory will be
+  created automatically if it does not exist.
+
 ## [0.2.1] - 2020-07-01
 ### Fixed
 - `appmap.output.directory` will be created if it does not exist. Previously this resulted in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - In `appmap.yml` a package item can now have an empty `path`, allowing the user to specify
   a list of exclusions only. This can be useful for excluding groups of tests not meant to
   be captured.
-- The default output directory for appmap files is now `./appmap`. This directory will be
+- The default output directory for appmap files is now `./tmp/appmap`. This directory will be
   created automatically if it does not exist.
 
 ## [0.2.1] - 2020-07-01

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ test {
 # System Properties
 
 * `appmap.config.file` Path to the `appmap.yml` config file. Default: _appmap.yml_
-* `appmap.output.directory` Output directory for `appmap.json` files. Default: `./appmap`
+* `appmap.output.directory` Output directory for `appmap.json` files. Default: `./tmp/appmap`
 * `appmap.debug` Enable debug logging. Default: disabled
 * `appmap.event.valueSize` Specifies the length of a value string before truncation occurs. If set to `0`, truncation is disabled. Default: `1024`
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ AppLand AppMap Recorder for Java
 - [Operation](#operation)
   - [Recording test cases](#recording-test-cases)
   - [HTTP recording controls](#http-recording-controls)
-    - [`GET /_appmap/record`](#get-appmaprecord)
-    - [`POST /_appmap/record`](#post-appmaprecord)
-    - [`DELETE /_appmap/record`](#delete-appmaprecord)
+    - [`GET /_appmap/record`](#get-_appmaprecord)
+    - [`POST /_appmap/record`](#post-_appmaprecord)
+    - [`DELETE /_appmap/record`](#delete-_appmaprecord)
 - [Developing](#developing)
   - [Testing](#testing)
 - [Build status](#build-status)
@@ -61,8 +61,9 @@ test {
 # System Properties
 
 * `appmap.config.file` Path to the `appmap.yml` config file. Default: _appmap.yml_
-* `appmap.output.directory` Output directory for `appmap.json` files. Default: current working directory
+* `appmap.output.directory` Output directory for `appmap.json` files. Default: `./appmap`
 * `appmap.debug` Enable debug logging. Default: disabled
+* `appmap.event.valueSize` Specifies the length of a value string before truncation occurs. If set to `0`, truncation is disabled. Default: `1024`
 
 # Operation
 

--- a/appmap.yml
+++ b/appmap.yml
@@ -1,4 +1,4 @@
 name: AppMap - Java
 packages:
-- path: com.appland
-  exclude:
+- path: com.appland.appmap.test.util
+- exclude: [ com.appland.appmap.integration.RecorderTest ]

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.2.1'
+version = '0.3.0'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ import com.appland.tasks.ShadowRelocation
 plugins {
   id 'java'
   id 'war'
-  id 'org.gretty' version '2.2.0'
   id 'jacoco'
 }
 
@@ -46,16 +45,6 @@ jar {
 
 apply plugin: 'com.github.johnrengelman.shadow'
 
-test {
-  useJUnit()
-  dependsOn shadowJar
-  dependsOn cleanTest
-  // jvmArgs "-javaagent:${shadowJar.archivePath}"
-  // systemProperty "appmap.debug", "true"
-  // systemProperty "appmap.config.file", "$rootDir/appmap.yml"
-  // systemProperty "appmap.output.directory", "$rootDir/build/appmap"
-}
-
 shadowJar {
   baseName = 'appmap'
   classifier = null
@@ -63,6 +52,37 @@ shadowJar {
   dependencies {
     exclude(dependency('javax.servlet:javax.servlet-api:4.0.1'))
   }
+}
+
+sourceSets {
+  integrationTest {
+    java {
+      srcDirs = [ 'src/test/java/com/appland/appmap/integration' ]
+    }
+    compileClasspath += main.output + test.output + sourceSets.test.compileClasspath
+    runtimeClasspath += main.output + test.output + sourceSets.test.runtimeClasspath
+  }
+}
+
+task integrationTest(type: Test) {
+  description = 'Runs integration tests.'
+  group = 'verification'
+
+  testClassesDirs = sourceSets.integrationTest.output.classesDirs
+  classpath = sourceSets.integrationTest.runtimeClasspath
+
+  dependsOn shadowJar
+  maxParallelForks = 1
+  jvmArgs "-javaagent:${shadowJar.destinationDir}/appmap-${version}.jar"
+  systemProperty "appmap.debug", "true"
+  systemProperty "appmap.config.file", "$rootDir/appmap.yml"
+}
+
+test {
+  useJUnit()
+  dependsOn shadowJar
+  dependsOn cleanTest
+  exclude 'com/appland/appmap/integration/**'
 }
 
 task relocateShadowJar(type: ShadowRelocation) {

--- a/src/main/java/com/appland/appmap/Agent.java
+++ b/src/main/java/com/appland/appmap/Agent.java
@@ -30,7 +30,9 @@ public class Agent {
   public static void premain(String agentArgs, Instrumentation inst) {
     final File dir = new File(Properties.OutputDirectory);
     if (!dir.exists()) {
-      dir.mkdir();
+      if (!dir.mkdirs()) {
+        Logger.println("failed to create directories: " + Properties.OutputDirectory);
+      }
     }
 
     Logger.printf("AppMap: agent loaded using config %s\n", Properties.ConfigFile);

--- a/src/main/java/com/appland/appmap/Agent.java
+++ b/src/main/java/com/appland/appmap/Agent.java
@@ -1,6 +1,7 @@
 package com.appland.appmap;
 
 import com.appland.appmap.config.AppMapConfig;
+import com.appland.appmap.config.Properties;
 import com.appland.appmap.record.ActiveSessionException;
 import com.appland.appmap.record.Recorder;
 import com.appland.appmap.transform.ClassFileTransformer;
@@ -20,9 +21,6 @@ import java.lang.instrument.Instrumentation;
  * When the agent exits, any un-printed data will be written to the file <code>appmap.json</code>.
  */
 public class Agent {
-
-  private final static String DEFAULT_CONFIG_FILE = "appmap.yml";
-
   /**
    * premain is the entry point for the AppMap Java agent.
    * @param agentArgs agent options
@@ -30,25 +28,17 @@ public class Agent {
    * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/lang/instrument/package-summary.html">Package java.lang.instrument</a>
    */
   public static void premain(String agentArgs, Instrumentation inst) {
-    String appmapPath = System.getProperty("appmap.config.file");
-    if (appmapPath == null) {
-      appmapPath = DEFAULT_CONFIG_FILE;
+    final File dir = new File(Properties.OutputDirectory);
+    if (!dir.exists()) {
+      dir.mkdir();
     }
 
-    final String outputDirectory = System.getProperty("appmap.output.directory");
-    if (outputDirectory != null) {
-      final File dir = new File(outputDirectory);
-      if (!dir.exists()) {
-        dir.mkdir();
-      }
-    }
-
-    Logger.printf("AppMap: agent loaded using config %s\n", appmapPath);
+    Logger.printf("AppMap: agent loaded using config %s\n", Properties.ConfigFile);
 
     inst.addTransformer(new ClassFileTransformer());
 
-    if (AppMapConfig.load(new File(appmapPath)) == null) {
-      Logger.printf("AppMap: failed to load config %s\n", appmapPath);
+    if (AppMapConfig.load(new File(Properties.ConfigFile)) == null) {
+      Logger.printf("AppMap: failed to load config %s\n", Properties.ConfigFile);
       return;
     }
 

--- a/src/main/java/com/appland/appmap/Agent.java
+++ b/src/main/java/com/appland/appmap/Agent.java
@@ -35,12 +35,12 @@ public class Agent {
       }
     }
 
-    Logger.printf("AppMap: agent loaded using config %s\n", Properties.ConfigFile);
+    Logger.printf("agent loaded using config %s\n", Properties.ConfigFile);
 
     inst.addTransformer(new ClassFileTransformer());
 
     if (AppMapConfig.load(new File(Properties.ConfigFile)) == null) {
-      Logger.printf("AppMap: failed to load config %s\n", Properties.ConfigFile);
+      Logger.printf("failed to load config %s\n", Properties.ConfigFile);
       return;
     }
 

--- a/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -67,4 +67,21 @@ public class AppMapConfig {
 
     return false;
   }
+
+  /**
+   * Check if a class/method is explicitly excluded in the configuration.
+   * @param className The class name to be checked
+   * @param methodName The method name to be checked
+   * @param isStatic {@code true} if the method is static
+   * @return {@code true} if the class/method is explicitly excluded in the configuration. Otherwise, {@code false}.
+   */
+  public Boolean excludes(String className, String methodName, boolean isStatic) {
+    for (AppMapPackage pkg : this.packages) {
+      if (pkg.excludes(className, methodName, isStatic)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/src/main/java/com/appland/appmap/config/AppMapPackage.java
+++ b/src/main/java/com/appland/appmap/config/AppMapPackage.java
@@ -15,6 +15,10 @@ public class AppMapPackage {
   public Boolean includes(String className, String methodName, boolean isStatic) {
     String canonicalName = className + (isStatic ? "." : "#") + methodName;
 
+    if (this.path == null) {
+      return false;
+    }
+
     if (!canonicalName.startsWith(this.path)) {
       return false;
     }

--- a/src/main/java/com/appland/appmap/config/AppMapPackage.java
+++ b/src/main/java/com/appland/appmap/config/AppMapPackage.java
@@ -13,7 +13,7 @@ public class AppMapPackage {
    *         is not included or otherwise explicitly excluded.
    */
   public Boolean includes(String className, String methodName, boolean isStatic) {
-    String canonicalName = className + (isStatic ? "." : "#") + methodName;
+    final String canonicalName = className + (isStatic ? "." : "#") + methodName;
 
     if (this.path == null) {
       return false;
@@ -23,12 +23,33 @@ public class AppMapPackage {
       return false;
     }
 
+    return !this.excludes(canonicalName);
+  }
+
+  /**
+   * Returns whether or not the canonical name is explicitly excluded
+   * @param canonicalName
+   * @return
+   */
+  private Boolean excludes(String canonicalName) {
     for (String exclusion : this.exclude) {
       if (canonicalName.startsWith(exclusion)) {
-        return false;
+        return true;
       }
     }
 
-    return true;
+    return false;
+  }
+
+  /**
+   * Check if a class/method is explicitly excluded in the configuration.
+   * @param className The class name to be checked
+   * @param methodName The method name to be checked
+   * @param isStatic {@code true} if the method is static
+   * @return {@code true} if the class/method is explicitly excluded in the configuration. Otherwise, {@code false}.
+   */
+  public Boolean excludes(String className, String methodName, boolean isStatic) {
+    final String canonicalName = className + (isStatic ? "." : "#") + methodName;
+    return this.excludes(canonicalName);
   }
 }

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -1,0 +1,53 @@
+package com.appland.appmap.config;
+
+import com.appland.appmap.util.Logger;
+
+import java.util.function.Function;
+
+public class Properties {
+  public static final Boolean Debug = (System.getProperty("appmap.debug") != null);
+
+  public static final String DefaultOutputDirectory = "./tmp/appmap";
+  public static final String OutputDirectory = resolveProperty(
+      "appmap.output.directory", DefaultOutputDirectory);
+
+  public static final String DefaultConfigFile = "appmap.yml";
+  public static final String ConfigFile = resolveProperty(
+      "appmap.config.file", DefaultConfigFile);
+
+  public static final Integer DefaultMaxValueSize = 1024;
+  public static final Integer MaxValueSize = resolveProperty(
+      "appmap.event.valueSize", Integer::valueOf, DefaultMaxValueSize);
+
+  private static String resolveProperty(String propName, String defaultValue) {
+    String value = defaultValue;
+    try {
+      final String propValue = System.getProperty(propName);
+      if (propValue != null) {
+        value = propValue;
+      }
+    } catch (Exception e) {
+      Logger.printf("failed to resolve %f, falling back to default\n", propName);
+      Logger.println(e);
+    }
+    return value;
+  }
+
+  private static <T> T resolveProperty(String propName,
+                                       Function<String, T> resolvingFunc,
+                                       T defaultValue) {
+    T value = defaultValue;
+    try {
+      final String propValue = System.getProperty(propName);
+      if (propValue != null) {
+        value = resolvingFunc.apply(propValue);
+      }
+    } catch (Exception e) {
+      Logger.printf("failed to resolve %f, falling back to default\n", propName);
+      Logger.println(e);
+
+      value = defaultValue;
+    }
+    return value;
+  }
+}

--- a/src/main/java/com/appland/appmap/output/v1/ParametersSerializer.java
+++ b/src/main/java/com/appland/appmap/output/v1/ParametersSerializer.java
@@ -47,7 +47,7 @@ public class ParametersSerializer implements ObjectSerializer {
       Field valuesField = Parameters.class.getDeclaredField("values");
       out.write(JSON.toJSONString(valuesField.get(params)));
     } catch (Exception e) {
-      Logger.println("AppMap: failed to serialize parameters");
+      Logger.println("failed to serialize parameters");
       Logger.println(e.getMessage());
       out.writeNull();
     }

--- a/src/main/java/com/appland/appmap/output/v1/Value.java
+++ b/src/main/java/com/appland/appmap/output/v1/Value.java
@@ -2,6 +2,10 @@ package com.appland.appmap.output.v1;
 
 import com.alibaba.fastjson.annotation.JSONField;
 import com.alibaba.fastjson.serializer.ToStringSerializer;
+import com.appland.appmap.config.Properties;
+import com.appland.appmap.util.Logger;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A serializable snapshot of a runtime Object.
@@ -114,7 +118,13 @@ public class Value {
     if (this.value != null) {
       try {
         this.value = this.value.toString();
+
+        if (Properties.MaxValueSize > 0 && this.value != null) {
+          this.value = StringUtils.abbreviate((String) this.value, "...", Properties.MaxValueSize);
+        }
       } catch (Throwable e) {
+        Logger.println("failed to resolve value of " + this.classType);
+        Logger.println(e.getMessage());
         // it's possible our value object has been partially cleaned up and
         // calls toString on a null object or the operation is otherwise
         // unsupported

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -165,7 +165,7 @@ public class ToggleRecord {
 
       recorder.start(fileName, metadata);
     } catch (ActiveSessionException e) {
-      Logger.printf("AppMap: %s\n", e.getMessage());
+      Logger.printf("%s\n", e.getMessage());
     }
   }
 
@@ -173,7 +173,7 @@ public class ToggleRecord {
     try {
       recorder.stop();
     } catch (ActiveSessionException e) {
-      Logger.printf("AppMap: %s\n", e.getMessage());
+      Logger.printf("%s\n", e.getMessage());
     }
   }
 

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -1,11 +1,12 @@
 package com.appland.appmap.record;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.Map;
 
 import com.appland.appmap.output.v1.CodeObject;
 import com.appland.appmap.output.v1.Event;
-import com.appland.appmap.process.ThreadLock;
 import com.appland.appmap.util.Logger;
 
 /**
@@ -58,6 +59,15 @@ public class Recorder {
     return this.activeSession != null;
   }
 
+  public synchronized IRecordingSession getActiveSession()
+      throws ActiveSessionException {
+    if (this.activeSession == null) {
+      throw new ActiveSessionException(ERROR_NO_SESSION);
+    }
+
+    return this.activeSession;
+  }
+
   /**
    * Start a recording session, writing the output to a file.
    * @param fileName Destination file
@@ -79,17 +89,25 @@ public class Recorder {
     this.setActiveSession(new RecordingSessionMemory(metadata));
   }
 
-  private void writeEvent(Event event) throws ActiveSessionException {
+  /**
+   * Freeze the event and write it to the active session. Do NOT call this
+   * method from within a block locked by `this`. Freezing an event will step
+   * into target application code, potentially accessing a locked resource and
+   * entering a deadlocked state.
+   */
+  private void writeEvent(Event event, IRecordingSession recordingSession)
+      throws ActiveSessionException {
     event.freeze();
-    this.activeSession.add(event);
 
     CodeObject rootObject = this.globalCodeObjects.getMethodBranch(event.definedClass,
-        event.methodId,
-        event.isStatic,
-        event.lineNumber);
+          event.methodId,
+          event.isStatic,
+          event.lineNumber);
+
+    recordingSession.add(event);
 
     if (rootObject != null) {
-      this.add(rootObject);
+      recordingSession.add(rootObject);
     }
   }
 
@@ -97,32 +115,45 @@ public class Recorder {
    * Flush all queued events, writing them to the active session and clearing
    * the queue.
    */
-  private synchronized void flush() {
-    try {
-      for (Event event : this.queuedEvents.values()) {
-        this.writeEvent(event);
-      }
-    } catch (ActiveSessionException e) {
-      Logger.printf("AppMap: failed to record event\n%s\n", e.getMessage());
-      this.activeSession.stop();
+  private void flush(IRecordingSession recordingSession) throws ActiveSessionException {
+    Collection<Event> events;
+
+    synchronized (this) {
+      events = new LinkedList<Event>(this.queuedEvents.values());
+      this.queuedEvents.clear();
     }
-    
-    this.queuedEvents.clear();
+
+    for (Event event : events) {
+      this.writeEvent(event, recordingSession);
+    }
   }
 
-  private synchronized void queueEvent(Event event) {
-    final Event pendingEvent = this.queuedEvents.get(event.threadId);
-    if (pendingEvent != null) {
-      try {
-        this.writeEvent(pendingEvent);
-      } catch (ActiveSessionException e) {
-        Logger.printf("AppMap: failed to record event\n%s\n", e.getMessage());
-        this.activeSession.stop();
+  private void queueEvent(Event event) throws ActiveSessionException {
+    Event pendingEvent;
+    IRecordingSession recordingSession;
+
+    synchronized (this) {
+      if (this.activeSession == null) {
         return;
       }
+
+      recordingSession = this.activeSession;
+      pendingEvent = this.queuedEvents.get(event.threadId);
+      this.queuedEvents.put(event.threadId, event);
     }
 
-    this.queuedEvents.put(event.threadId, event);
+    if (pendingEvent != null) {
+      this.writeEvent(pendingEvent, recordingSession);
+    }
+  }
+
+  private synchronized void forceStop() {
+    if (this.activeSession == null) {
+      return;
+    }
+
+    this.activeSession.stop();
+    this.activeSession = null;
   }
 
   /**
@@ -131,55 +162,35 @@ public class Recorder {
    * @throws ActiveSessionException If no recording session is in progress or the session cannot be
    *                                stopped.
    */
-  public synchronized String stop() throws ActiveSessionException {
-    if (!this.hasActiveSession()) {
-      throw new ActiveSessionException(ERROR_NO_SESSION);
+  public String stop() throws ActiveSessionException {
+    IRecordingSession recordingSession;
+
+    synchronized (this) {
+      recordingSession = this.getActiveSession();
+      this.activeSession = null;
     }
 
-    // make sure there's no queued event waiting to be written
-    this.flush();
-
-    String output = "";
-
-    ThreadLock processorStack = ThreadLock.current();
     try {
-      processorStack.enter();
-      processorStack.lock();
-      output = this.activeSession.stop();
+      this.flush(recordingSession);
+      return recordingSession.stop();
     } catch (ActiveSessionException e) {
-      Logger.printf("AppMap: failed to stop recording\n%s\n", e.getMessage());
-    } finally {
-      processorStack.unlock();
-      processorStack.exit();
+      Logger.printf("failed to stop recording\n%s\n", e.getMessage());
+      this.forceStop();
+      return "";
     }
-
-    this.activeSession = null;
-
-    return output;
   }
 
   /**
    * Record an {@link Event} to the active session.
    * @param event The event to be recorded.
    */
-  public synchronized void add(Event event) {
-    if (!this.hasActiveSession()) {
-      return;
-    }
-
-    this.queueEvent(event);
-  }
-
-  private synchronized void add(CodeObject codeObject) {
-    if (!this.hasActiveSession()) {
-      return;
-    }
-
+  public void add(Event event) {
     try {
-      this.activeSession.add(codeObject);
+      this.queueEvent(event);
     } catch (ActiveSessionException e) {
-      Logger.printf("AppMap: failed to record code object\n%s\n", e.getMessage());
-      this.activeSession.stop();
+      Logger.println("failed to record event");
+      Logger.println(e);
+      this.forceStop();
     }
   }
 

--- a/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
@@ -92,7 +92,7 @@ public class RecordingSessionFileStream extends RecordingSessionGeneric {
       );
     }
 
-    Logger.printf("AppMap: wrote %s\n", this.fileName);
+    Logger.printf("wrote %s\n", this.fileName);
 
     return "";
   }

--- a/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
@@ -76,6 +76,10 @@ public class RecordingSessionFileStream extends RecordingSessionGeneric {
 
   @Override
   public synchronized String stop() {
+    if (this.serializer == null) {
+      return "";
+    }
+
     this.flushEvents();
 
     try {

--- a/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
@@ -1,5 +1,6 @@
 package com.appland.appmap.record;
 
+import com.appland.appmap.config.Properties;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.util.Logger;
 
@@ -13,19 +14,11 @@ import java.nio.file.Paths;
 public class RecordingSessionFileStream extends RecordingSessionGeneric {
   private static final Integer MAX_EVENTS = 32;
   private static final String DEFAULT_FILENAME = "appmap.json";
-  private static String OUTPUT_DIRECTORY = "./";
 
   private FileWriter fileWriter;
   private final Metadata metadata;
   private String fileName = DEFAULT_FILENAME;
   private AppMapSerializer serializer;
-
-  static {
-    String outputDirectory = System.getProperty("appmap.output.directory");
-    if (outputDirectory != null) {
-      OUTPUT_DIRECTORY = outputDirectory;
-    }
-  }
 
   /**
    * Constructor. You typically shouldn't be creating this outside of the {@link Recorder}.
@@ -63,7 +56,7 @@ public class RecordingSessionFileStream extends RecordingSessionGeneric {
   @Override
   public void start() {
     try {
-      String filePath = Paths.get(OUTPUT_DIRECTORY, this.fileName).toString();
+      String filePath = Paths.get(Properties.OutputDirectory, this.fileName).toString();
       this.fileWriter = new FileWriter(filePath);
       this.serializer = new AppMapSerializer(this.fileWriter);
     } catch (IOException e) {

--- a/src/main/java/com/appland/appmap/record/RecordingSessionGeneric.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionGeneric.java
@@ -9,11 +9,11 @@ public class RecordingSessionGeneric implements IRecordingSession {
   protected Vector<Event> events = new Vector<Event>();
   protected CodeObjectTree codeObjects = new CodeObjectTree();
 
-  public void add(Event event) {
+  public synchronized void add(Event event) {
     this.events.add(event);
   }
 
-  public void add(CodeObject codeObject) {
+  public synchronized void add(CodeObject codeObject) {
     this.codeObjects.add(codeObject);
   }
 

--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -48,7 +48,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
         CtClass ctClass = classPool.get(classType.getName());
         processClass(ctClass);
       } catch (NotFoundException e) {
-        Logger.printf("AppMap: failed to find %s in class pool", classType.getName());
+        Logger.printf("failed to find %s in class pool", classType.getName());
         Logger.println(e.getMessage());
       }
     } 
@@ -98,14 +98,14 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
       try {
         hook.validate();
       } catch (HookValidationException e) {
-        Logger.println("AppMap: failed to validate hook");
+        Logger.println("failed to validate hook");
         Logger.println(e.getMessage());
         continue;
       }
 
       this.addHook(hook);
 
-      Logger.printf("AppMap: registered hook %s\n", hook.toString());
+      Logger.printf("registered hook %s\n", hook.toString());
     }
   }
 
@@ -125,7 +125,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
 
       for (HookSite hookSite : hookSites) {
         final Hook hook = hookSite.getHook();
-        Logger.printf("AppMap: hooked %s.%s (%s) with %s\n",
+        Logger.printf("hooked %s.%s (%s) with %s\n",
               behavior.getDeclaringClass().getName(),
               behavior.getName(),
               hook.getMethodEvent().getEventString(),

--- a/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
@@ -53,7 +53,7 @@ public class CallbackOnSystem extends BaseSystem {
 
           runtimeParameters.add(returnValue);
         } catch (NotFoundException e) {
-          Logger.println("AppMap: warning - unknown return type");
+          Logger.println("warning - unknown return type");
           Logger.println(e.getMessage());
         }
       }

--- a/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
@@ -41,7 +41,7 @@ class CtClassUtil {
         superClass = superClass.getSuperclass();
       }
     } catch (NotFoundException e) {
-      Logger.println("AppMap: could not resolve class hierarchy");
+      Logger.println("could not resolve class hierarchy");
       Logger.println(e.getMessage());
     }
 

--- a/src/main/java/com/appland/appmap/transform/annotations/Hook.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/Hook.java
@@ -76,7 +76,7 @@ public class Hook {
     Hook hook = new Hook(sourceSystem, optionalSystems, hookBehavior);
     for (ISystem optionalSystem : optionalSystems) {
       if (!optionalSystem.validate(hook)) {
-        Logger.println("AppMap: hook "
+        Logger.println("hook "
             + hook
             + " failed validation from "
             + optionalSystem.getClass().getSimpleName());
@@ -188,15 +188,15 @@ public class Hook {
           ClassPool.getDefault().get("java.lang.Exception"));
       
     } catch (CannotCompileException e) {
-      Logger.println("AppMap: failed to compile");
-      Logger.println("        method "
+      Logger.println("failed to compile");
+      Logger.println("       method "
           + targetBehavior.getDeclaringClass().getName()
           + "."
           + targetBehavior.getName());
 
       Logger.println(e.getMessage());
     } catch (NotFoundException e) {
-      Logger.println("AppMap: failed to find class\n");
+      Logger.println("failed to find class\n");
       Logger.println(e.getMessage());
     }
   }
@@ -284,7 +284,7 @@ public class Hook {
       try {
         returnType = ((CtMethod) behavior).getReturnType();
       } catch (NotFoundException e) {
-        Logger.println("AppMap: warning - unknown return type");
+        Logger.println("warning - unknown return type");
         Logger.println(e.getMessage());
       }
     }

--- a/src/main/java/com/appland/appmap/transform/annotations/HookAnnotatedSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookAnnotatedSystem.java
@@ -1,6 +1,8 @@
 package com.appland.appmap.transform.annotations;
 
-import com.appland.appmap.util.Logger;
+import java.lang.reflect.Modifier;
+
+import com.appland.appmap.config.AppMapConfig;
 
 import javassist.CtBehavior;
 
@@ -29,9 +31,11 @@ public class HookAnnotatedSystem extends SourceMethodSystem {
 
   @Override
   public Boolean match(CtBehavior behavior) {
-    if (behavior.hasAnnotation(this.annotationClass)) {
-      Logger.println("!!");
-    }
-    return behavior.hasAnnotation(this.annotationClass);
+    final Boolean isExplicitlyExcluded = AppMapConfig.get().excludes(
+        behavior.getDeclaringClass().getName(),
+        behavior.getMethodInfo().getName(),
+        Modifier.isStatic(behavior.getModifiers()));
+
+    return behavior.hasAnnotation(this.annotationClass) && !isExplicitlyExcluded;
   }
 }

--- a/src/main/java/com/appland/appmap/transform/annotations/HookConditionSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookConditionSystem.java
@@ -56,7 +56,7 @@ public class HookConditionSystem extends SourceMethodSystem {
     try {
       return (Boolean) this.conditionMethod.invoke(null, behavior);
     } catch (Exception e) {
-      Logger.printf("AppMap: match failed due to %s exception\n", e.getClass().getName());
+      Logger.printf("match failed due to %s exception\n", e.getClass().getName());
       Logger.println(e.getMessage());
       return false;
     }

--- a/src/main/java/com/appland/appmap/util/Logger.java
+++ b/src/main/java/com/appland/appmap/util/Logger.java
@@ -1,14 +1,14 @@
 package com.appland.appmap.util;
 
-public class Logger {
-  private static final Boolean debug = (System.getProperty("appmap.debug") != null);
+import com.appland.appmap.config.Properties;
 
+public class Logger {
   public static void println(Exception e) {
     Logger.println(e.getMessage());
   }
 
   public static void println(String msg) {
-    if (!debug) {
+    if (!Properties.Debug) {
       return;
     }
 
@@ -16,7 +16,7 @@ public class Logger {
   }
 
   public static void printf(String format, Object... args) {
-    if (!debug) {
+    if (!Properties.Debug) {
       return;
     }
 

--- a/src/test/java/com/appland/appmap/integration/MultithreadedTest.java
+++ b/src/test/java/com/appland/appmap/integration/MultithreadedTest.java
@@ -1,0 +1,29 @@
+package com.appland.appmap.integration;
+
+import com.appland.appmap.test.util.LockedResource;
+
+import org.junit.Test;
+
+public class MultithreadedTest {
+  @Test(timeout = 15000)
+  public void testLockedResourceValue() throws InterruptedException {
+    final int iterations = 5;
+    LockedResource lockedResource = new LockedResource();
+
+    Thread t = new Thread(() -> {
+      try {
+        for (int i = 0; i < iterations; ++i) {
+          lockedResource.lockingMethod();
+        }
+      } catch (InterruptedException e) {
+        // end scope
+      }
+    });
+
+    t.start();
+    for (int i = 0; i < iterations; ++i) {
+      lockedResource.lockingMethod();
+    }
+    t.join();
+  }
+}

--- a/src/test/java/com/appland/appmap/integration/RecorderTest.java
+++ b/src/test/java/com/appland/appmap/integration/RecorderTest.java
@@ -1,0 +1,80 @@
+package com.appland.appmap.integration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.appland.appmap.config.Properties;
+import com.appland.appmap.record.ActiveSessionException;
+import com.appland.appmap.record.Recorder;
+import com.appland.appmap.test.util.MyClass;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public class RecorderTest {
+  private static final Recorder recorder = Recorder.getInstance();
+
+  @Test
+  public void testRecordBlock() {
+    final MyClass myClass = new MyClass();
+    final String scenario = recorder.record(() -> {
+      for (int i = 0; i < 10; i++) {
+        myClass.myMethod();
+      }
+    });
+    assertNotNull(scenario);
+  }
+
+  @Test
+  public void testRecordBlockToFile() throws IOException {
+    final MyClass myClass = new MyClass();
+    final File output = new File(Paths.get(Properties.OutputDirectory, "Recording_a_block_to_a_file.appmap.json").toString());
+
+    if (output.exists()) {
+      output.delete();
+    }
+
+    recorder.record("Recording a block to a file", () -> {
+      for (int i = 0; i < 10; i++) {
+        myClass.myMethod();
+      }
+    });
+
+    assertTrue(output.exists());
+  }
+
+  @Test(timeout = 5000)
+  public void testMultiThreadedRecordBlock() throws IOException, InterruptedException {
+    final int iterations = 1000;
+    final MyClass myClass = new MyClass();
+    Thread t = new Thread(() -> {
+      for (int i = 0; i < iterations; i++) {
+        try {
+          recorder.record(() -> {
+            myClass.myMethod();
+          });
+        } catch (ActiveSessionException e) {
+          // good, continue
+        }
+      }
+    });
+
+    t.start();
+    for (int i = 0; i < iterations; i++) {
+      try {
+        recorder.record(() -> {
+          myClass.myMethod();
+        });
+      } catch (ActiveSessionException e) {
+        // good, continue
+      }
+    }
+
+    t.join();
+    assertFalse(recorder.hasActiveSession());
+  }
+}

--- a/src/test/java/com/appland/appmap/test/util/LockedResource.java
+++ b/src/test/java/com/appland/appmap/test/util/LockedResource.java
@@ -1,0 +1,14 @@
+package com.appland.appmap.test.util;
+
+public class LockedResource {
+  public synchronized void lockingMethod() throws InterruptedException {
+    Thread.sleep(1000);
+  }
+
+  @Override
+  public String toString() {
+    synchronized (this) {
+      return "hello world";
+    }
+  }
+}

--- a/src/test/java/com/appland/appmap/test/util/MyClass.java
+++ b/src/test/java/com/appland/appmap/test/util/MyClass.java
@@ -1,0 +1,7 @@
+package com.appland.appmap.test.util;
+
+public class MyClass {
+  public void myMethod() {
+    // do nothing
+  }
+}


### PR DESCRIPTION
This PR includes various fixes and changes I've made as a result of a bunch of testing with Jenkins. This is also a follow up to some issues observed during user testing, namely the deadlock fix.

### Fixed
- **Removed a potential deadlock** that could occur if the user's code required a lock in `toString`.

### Added
- `appmap.event.valueSize` can be used to specify the length of a value string before truncation occurs.
- `Recorder.record` will record and output the execution of a `Runnable`. Examples can be found [here](https://github.com/applandinc/appmap-java/blob/60a83b18ba1164ce6f10bdfb3c4e6fba4d048b97/src/test/java/com/appland/appmap/integration/RecorderTest.java#L41-L45) and [here](https://github.com/applandinc/appmap-java/blob/60a83b18ba1164ce6f10bdfb3c4e6fba4d048b97/src/test/java/com/appland/appmap/integration/RecorderTest.java#L24-L28).
- Integration tests now exist outside of bats. These are currently normal JUnit tests but they're run with the agent attached. It's currently being used to test for race conditions/deadlocks as well as recording blocks. This means **we're finally recording appmaps from our own project**.

### Changed
- In `appmap.yml` a package item can now have an empty `path`, allowing the user to specify a list of exclusions only. This can be useful for excluding groups of tests not meant to be captured.
- The default output directory for appmap files is now `./appmap`. This directory will be created automatically if it does not exist.