### PR TITLE
Testing behavior is the same with/without the agent attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2020-07-15
+### Fixed
+- Dependencies of `appmap-java` which use `slf4j` will now use a nop implementation in order
+  to stop them from logging if the client application provides it's own implementation. If left
+  up to the client application, `appmap-java` can interfere with test frameworks by corrupting
+  stdout.
+- `appmap-java` will no longer call `Thread` methods that may be extended by the client application
+  resulting in a stack overflow.
+- `appmap-java` no longer assumes that `Thread` identifiers are unique. Previously, this could
+  result in concurrent modificiations to resources not meant to be shared across threads.
+
 ## [0.3.0] - 2020-07-08
 ### Fixed
 - Removed a potential deadlock that could occur if the user's code required a lock in `toString`.

--- a/appmap.yml
+++ b/appmap.yml
@@ -1,4 +1,7 @@
 name: AppMap - Java
 packages:
 - path: com.appland.appmap.test.util
+  exclude:
+  - com.appland.appmap.test.util.UnhandledExceptionCollection
+
 - exclude: [ com.appland.appmap.integration.RecorderTest ]

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,7 @@ dependencies {
   implementation 'org.reflections:reflections:0.9.11'
   implementation 'javax.servlet:javax.servlet-api:4.0.1'
   implementation 'org.apache.commons:commons-lang3:3.10'
-
-  annotationProcessor 'info.picocli:picocli-codegen:4.0.4'
+  implementation 'org.slf4j:slf4j-nop:1.7.30'
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.3.0'
+version = '0.3.1'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/buildSrc/src/main/groovy/com/appland/tasks/ShadowRelocation.groovy
+++ b/buildSrc/src/main/groovy/com/appland/tasks/ShadowRelocation.groovy
@@ -55,6 +55,7 @@ class ShadowRelocation extends DefaultTask {
       
       if (excluded) return
 
+      logger.info("relocating ${it} -> ${prefix}.${it}")
       target.relocate(it, "${prefix}.${it}")
     }
   }

--- a/src/main/java/com/appland/appmap/Agent.java
+++ b/src/main/java/com/appland/appmap/Agent.java
@@ -43,17 +43,5 @@ public class Agent {
       Logger.printf("failed to load config %s\n", Properties.ConfigFile);
       return;
     }
-
-    Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-        public void run() {
-          Recorder recorder = Recorder.getInstance();
-          try {
-            recorder.stop();
-          } catch (ActiveSessionException e) {
-            // do nothing
-            return;
-          }
-        }
-    }, "AppMap Shutdown Thread"));
   }
 }

--- a/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -59,6 +59,10 @@ public class AppMapConfig {
    *         is not included or otherwise explicitly excluded.
    */
   public Boolean includes(String className, String methodName, boolean isStatic) {
+    if (this.packages == null) {
+      return false;
+    }
+
     for (AppMapPackage pkg : this.packages) {
       if (pkg.includes(className, methodName, isStatic)) {
         return true;
@@ -76,6 +80,10 @@ public class AppMapConfig {
    * @return {@code true} if the class/method is explicitly excluded in the configuration. Otherwise, {@code false}.
    */
   public Boolean excludes(String className, String methodName, boolean isStatic) {
+    if (this.packages == null) {
+      return false;
+    }
+
     for (AppMapPackage pkg : this.packages) {
       if (pkg.excludes(className, methodName, isStatic)) {
         return true;

--- a/src/main/java/com/appland/appmap/process/ThreadLock.java
+++ b/src/main/java/com/appland/appmap/process/ThreadLock.java
@@ -39,11 +39,11 @@ public class ThreadLock {
       this.globalLock = globalLock;
     }
   }
-  private static final HashMap<Long, ThreadLock> instances =
-      new HashMap<Long, ThreadLock>();
+
+  private static final HashMap<Thread, ThreadLock> instances =
+      new HashMap<Thread, ThreadLock>();
 
   private final Stack<ThreadLockStatus> statusStack = new Stack<ThreadLockStatus>();
-  private Boolean isLocked = false;
 
   private ThreadLock() { }
 
@@ -52,12 +52,15 @@ public class ThreadLock {
    * @return A ThreadLock instance unique to the current thread
    */
   public static ThreadLock current() {
-    Long threadId = Thread.currentThread().getId();
-    ThreadLock instance = ThreadLock.instances.get(threadId);
+    Thread currentThread = Thread.currentThread();
+    ThreadLock instance = null;
+
+    instance = ThreadLock.instances.get(currentThread);
     if (instance == null) {
       instance = new ThreadLock();
-      ThreadLock.instances.put(threadId, instance);
+      ThreadLock.instances.put(currentThread, instance);
     }
+
     return instance;
   }
 
@@ -132,7 +135,7 @@ public class ThreadLock {
       return false;
     }
 
-    for(ThreadLockStatus status : this.statusStack) {
+    for (ThreadLockStatus status : this.statusStack) {
       if (status.contains(key)) {
         return false;
       }

--- a/src/test/java/com/appland/appmap/integration/ThreadTest.java
+++ b/src/test/java/com/appland/appmap/integration/ThreadTest.java
@@ -1,0 +1,62 @@
+package com.appland.appmap.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
+
+import com.appland.appmap.test.util.MyClass;
+import com.appland.appmap.test.util.MyThread;
+import com.appland.appmap.test.util.UnhandledExceptionCollection;
+
+import org.junit.Test;
+
+public class ThreadTest {
+  @Test
+  public void testHookingThreadSubclassDoesNotOverflowStack()
+      throws InterruptedException {
+    final MyThread t = new MyThread(() -> {
+      MyClass myClass = new MyClass();
+      myClass.myMethod();
+    });
+
+    UnhandledExceptionCollection exceptions = new UnhandledExceptionCollection();
+    t.setUncaughtExceptionHandler(exceptions);
+
+    t.start();
+    t.join();
+
+    assertFalse(exceptions.contains(StackOverflowError.class));
+  }
+
+  @Test
+  public void testConcurrentModificationNonUniqueThreadId()
+      throws InterruptedException {
+    final Runnable r = () -> {
+      final MyClass myClass = new MyClass();
+
+      for (int i = 0; i < 1000; ++i) {
+        myClass.myMethod();
+      }
+    };
+
+    final long sharedThreadId = 100;
+    final int  numThreads = 8;
+    final UnhandledExceptionCollection exceptions = new UnhandledExceptionCollection();
+    final ArrayList<Thread> threads = new ArrayList<Thread>();
+    for (int i = 0; i < numThreads; ++i) {
+      final MyThread t = new MyThread(sharedThreadId, r);
+      t.setUncaughtExceptionHandler(exceptions);
+      threads.add(t);
+      t.start();
+    }
+
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    assertFalse(exceptions.contains(ConcurrentModificationException.class));
+  }
+}

--- a/src/test/java/com/appland/appmap/test/util/MyThread.java
+++ b/src/test/java/com/appland/appmap/test/util/MyThread.java
@@ -1,0 +1,20 @@
+package com.appland.appmap.test.util;
+
+public class MyThread extends Thread {
+  private long id;
+
+  public MyThread(long threadId, Runnable runnable) {
+    super(runnable);
+    this.id = threadId;
+  }
+
+  public MyThread(Runnable runnable) {
+    super(runnable);
+    this.id = (long) Math.ceil(Math.random() * Long.MAX_VALUE);
+  }
+
+  @Override
+  public long getId() {
+    return this.id;
+  }
+}

--- a/src/test/java/com/appland/appmap/test/util/UnhandledExceptionCollection.java
+++ b/src/test/java/com/appland/appmap/test/util/UnhandledExceptionCollection.java
@@ -1,0 +1,23 @@
+package com.appland.appmap.test.util;
+
+import java.util.ArrayList;
+
+public class UnhandledExceptionCollection implements Thread.UncaughtExceptionHandler {
+  private ArrayList<Throwable> exceptions = new ArrayList<Throwable>();
+
+  public UnhandledExceptionCollection() {
+  }
+
+  public void uncaughtException(Thread th, Throwable ex) {
+    this.exceptions.add(ex);
+  }
+
+  public Boolean contains(Class<? extends Throwable> clazz) {
+    for (Throwable e : this.exceptions) {
+      if (clazz.isInstance(e)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
`0.3.1` Fixes issues spotted in the wild:
- Dependencies of `appmap-java` which use `slf4j` will now use a nop implementation in order to stop them from logging if the client application provides it's own implementation. If left up to the client application, `appmap-java` can interfere with test frameworks by corrupting stdout.
- `appmap-java` will no longer call `Thread` methods that may be extended by the client application resulting in a stack overflow.
- `appmap-java` no longer assumes that `Thread` identifiers are unique. Previously, this could result in concurrent modificiations to resources not meant to be shared across threads.