### PR TITLE
Add support for TestNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.4.0] - 2020-08-06
+### Added
+- Tests annotated with `org.testng.annotations.Test` are now recorded.
 
 ## [0.3.2] - 2020-07-30
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.3.2'
+version = '0.4.0'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -226,4 +226,29 @@ public class ToggleRecord {
     recorder.add(event);
     stopTest();
   }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @HookAnnotated("org.testng.annotations.Test")
+  public static void testng(Event event, Object[] args) {
+    startTest(event);
+  }
+
+  @ArgumentArray
+  @CallbackOn(MethodEvent.METHOD_RETURN)
+  @ExcludeReceiver
+  @HookAnnotated("org.testng.annotations.Test")
+  public static void testnt(Event event, Object returnValue, Object[] args) {
+    stopTest();
+  }
+
+  @ArgumentArray
+  @CallbackOn(MethodEvent.METHOD_EXCEPTION)
+  @ExcludeReceiver
+  @HookAnnotated("org.testng.annotations.Test")
+  public static void testng(Event event, Exception exception, Object[] args) {
+    event.setException(exception);
+    recorder.add(event);
+    stopTest();
+  }
 }


### PR DESCRIPTION
Tests annotated with `org.testng.annotations.Test` are now recorded.