### PR TITLE
Use less memory when recording

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ cache:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
 script:
-- ./gradlew check -s
-- ./gradlew integrationTest
+- ./gradlew -is check
+- ./gradlew -is integrationTest
 - ./bin/test
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 dist: bionic
 jdk:
 - openjdk8
-- oraclejdk11
+- openjdk11
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.4.1] - 2020-08-24
+### Changed
+- `appmap-java` now uses significantly less memory when recording.
+
 ## [0.4.0] - 2020-08-06
 ### Added
 - Tests annotated with `org.testng.annotations.Test` are now recorded.

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.4.0'
+version = '0.4.1'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 
 public class Properties {
   public static final Boolean Debug = (System.getProperty("appmap.debug") != null);
+  public static final Boolean DebugHooks = (System.getProperty("appmap.debug.hooks") != null);
 
   public static final String DefaultOutputDirectory = "./tmp/appmap";
   public static final String OutputDirectory = resolveProperty(

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 public class Properties {
   public static final Boolean Debug = (System.getProperty("appmap.debug") != null);
   public static final Boolean DebugHooks = (System.getProperty("appmap.debug.hooks") != null);
+  public static final Boolean DebugLocals = (System.getProperty("appmap.debug.locals") != null);
 
   public static final String DefaultOutputDirectory = "./tmp/appmap";
   public static final String OutputDirectory = resolveProperty(

--- a/src/main/java/com/appland/appmap/output/v1/CodeObject.java
+++ b/src/main/java/com/appland/appmap/output/v1/CodeObject.java
@@ -21,7 +21,7 @@ public class CodeObject {
   public String name = "";
   public String type = "";
   public String location = "";
-  public ArrayList<CodeObject> children = new ArrayList<CodeObject>();
+  private ArrayList<CodeObject> children = new ArrayList<CodeObject>();
 
   @JSONField(name = "static")
   public Boolean isStatic;
@@ -257,6 +257,29 @@ public class CodeObject {
     return null;
   }
 
+  private boolean equalBySubstring(String s1, String s2, int start, int end) {
+    int sublen = end - start;
+    if (s1.length() != sublen)
+      return false;
+
+    for (int idx = 0; idx < sublen; idx++) {
+      if (s1.charAt(idx) != s2.charAt(start + idx))
+        return false;
+    }
+
+    return true;
+  }
+  
+  public CodeObject findChildBySubstring(String name, int start, int end) {
+    for (CodeObject child : this.children) {
+      if (equalBySubstring(child.name, name, start, end)) {
+        return child;
+      }
+    }
+
+    return null;
+  }
+  
   /**
    * Set the "name" field.
    * @param name The name of this CodeObject
@@ -318,5 +341,13 @@ public class CodeObject {
     this.children.add(child);
 
     return this;
+  }
+
+  public ArrayList<CodeObject> getChildren() {
+    // Once, among many runs, I saw a ConcurrentAccessException on
+    // this.children. I wasn't able to reproduce it. If it comes back,
+    // though, it may be necessary to return a copy of it. 20200824, ajp
+    // return new ArrayList<CodeObject>(this.children);
+    return this.children;
   }
 }

--- a/src/main/java/com/appland/appmap/output/v1/NoSourceAvailableException.java
+++ b/src/main/java/com/appland/appmap/output/v1/NoSourceAvailableException.java
@@ -8,4 +8,7 @@ public class NoSourceAvailableException extends RuntimeException {
   public NoSourceAvailableException() {
     super();
   }
+  public NoSourceAvailableException(String msg) {
+    super(msg);
+  }
 }

--- a/src/main/java/com/appland/appmap/output/v1/Parameters.java
+++ b/src/main/java/com/appland/appmap/output/v1/Parameters.java
@@ -1,6 +1,7 @@
 package com.appland.appmap.output.v1;
 
 import com.appland.appmap.util.Logger;
+import com.appland.appmap.config.Properties;
 
 import javassist.CtBehavior;
 import javassist.CtClass;
@@ -73,8 +74,9 @@ public class Parameters implements Iterable<Value> {
     if (numParams > 0) {
       int numLocals = locals.tableLength();
       
-      // This is handy when debugging this code, put produces too much noise for general use.
-      if (false) {
+      // This is handy when debugging this code, but produces too much
+      // noise for general use.
+      if (Properties.DebugLocals) {
         Logger.println("local variables for " + fqn);
         for (int idx = 0; idx < numLocals; idx++) {
           Logger.printf("  %d %s %d\n", idx, locals.variableName(idx), locals.index(idx));

--- a/src/main/java/com/appland/appmap/output/v1/Parameters.java
+++ b/src/main/java/com/appland/appmap/output/v1/Parameters.java
@@ -7,7 +7,9 @@ import javassist.CtClass;
 import javassist.NotFoundException;
 import javassist.bytecode.CodeAttribute;
 import javassist.bytecode.LocalVariableAttribute;
+import javassist.bytecode.MethodParametersAttribute;
 import javassist.bytecode.MethodInfo;
+import javassist.bytecode.AttributeInfo;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -38,58 +40,87 @@ public class Parameters implements Iterable<Value> {
    */
   public Parameters(CtBehavior behavior) {
     MethodInfo methodInfo = behavior.getMethodInfo();
+    String fqn = behavior.getDeclaringClass().getName() +
+      "." + behavior.getName() +
+      methodInfo.getDescriptor();
+
     CodeAttribute codeAttribute = methodInfo.getCodeAttribute();
     if (codeAttribute == null) {
-      throw new NoSourceAvailableException();
+      throw new NoSourceAvailableException("No code attribute for " + fqn);
     }
-
+           
     LocalVariableAttribute locals = (LocalVariableAttribute) codeAttribute.getAttribute(
         javassist.bytecode.LocalVariableAttribute.tag);
 
+    // We should be able to handle methods without debug
+    // information. However, as of 20200822, other errors come up if
+    // do hook them, so bail out here.
     if (locals == null) {
-      throw new NoSourceAvailableException();
+      throw new NoSourceAvailableException("No local variables for " + fqn);
     }
 
-    Integer numberLocals = locals.tableLength();
-    CtClass[] parameterTypes = new CtClass[]{};
-
+    CtClass[] paramTypes = null;
     try {
-      parameterTypes = behavior.getParameterTypes();
+      paramTypes = behavior.getParameterTypes();
     } catch (NotFoundException e) {
-      Logger.println(
-          String.format("failed to get parameter types for %s.%s: %s",
-              behavior.getDeclaringClass().getName(),
-              behavior.getName(),
-              e.getMessage()));
+      throw new NoSourceAvailableException(
+        String.format("Failed to get parameter types for %s: %s",
+                      fqn, e.getMessage()));
     }
 
-    Boolean isStatic = (behavior.getModifiers() & Modifier.STATIC) != 0;
-    Value[] paramValues = new Value[parameterTypes.length];
-    for (int i = 0; i < numberLocals; ++i) {
-      // parameters are not neccesarily the first local variables
-      Integer paramIndex = locals.index(i);
-
-      if (!isStatic) {
-        // index 0 is `this` for nonstatic methods
-        // we don't need it
-        if (paramIndex == 0) {
-          continue;
+    String[] paramNames = null;
+    int numParams = paramTypes.length;
+    if (numParams > 0) {
+      int numLocals = locals.tableLength();
+      
+      // This is handy when debugging this code, put produces too much noise for general use.
+      if (false) {
+        Logger.println("local variables for " + fqn);
+        for (int idx = 0; idx < numLocals; idx++) {
+          Logger.printf("  %d %s %d\n", idx, locals.variableName(idx), locals.index(idx));
         }
-
-        // similarly, `parameterTypes` does not contain `this`, so shift our index back by one
-        paramIndex -= 1;
       }
 
-      if (paramIndex >= parameterTypes.length) {
-        continue;
+      paramNames = new String[numParams];
+      Boolean isStatic = (behavior.getModifiers() & Modifier.STATIC) != 0;
+      int firstParamIdx = isStatic ? 0 : 1; // ignore `this`
+      int localVarIdx = 0;
+      
+      // Scan the local variables until we find the one with an index
+      // that matches the first parameter index.
+      //
+      // In some cases, though, there aren't local variables for the
+      // parameters. For example, the class file for
+      // org.springframework.samples.petclinic.owner.PetTypeFormatter,
+      // has the method
+      // print(Ljava/lang/Object;Ljava/util/Locale;)Ljava/lang/String
+      // in it, which only has a local variable for `this`. This
+      // method isn't in the source file, so I'm not sure where it's
+      // coming from.
+      for (; localVarIdx < numLocals; localVarIdx++) {
+        if (locals.index(localVarIdx) == firstParamIdx)
+          break;
       }
 
+      if (localVarIdx < numLocals) {
+        // Assume the rest of the parameters follow the first.
+        paramNames[0] = locals.variableName(localVarIdx);
+        for (int idx = 1; idx < numParams; idx++)
+          paramNames[idx] = locals.variableName(localVarIdx + idx);
+      }
+    }
+
+    Value[] paramValues = new Value[numParams];
+    for (int i = 0; i < paramTypes.length; ++i) {
+      // Use a real parameter name if we have it, a fake one if we
+      // don't.
+      String paramName = paramNames != null? paramNames[i] : "p" + i;
       Value param = new Value()
-          .setClassType(parameterTypes[paramIndex].getName())
-          .setName(locals.variableName(i))
+          .setClassType(paramTypes[i].getName())
+          .setName(paramName)
           .setKind("req");
 
-      paramValues[paramIndex] = param;
+      paramValues[i] = param;
     }
 
     for (int i = 0; i < paramValues.length; ++i) {

--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -125,13 +125,15 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
 
       for (HookSite hookSite : hookSites) {
         final Hook hook = hookSite.getHook();
-        Logger.printf("hooked %s.%s (%s) with %s\n",
+        Logger.printf("hooked %s.%s%s on (%s) with %s\n",
               behavior.getDeclaringClass().getName(),
               behavior.getName(),
+              behavior.getMethodInfo().getDescriptor(),
               hook.getMethodEvent().getEventString(),
               hook);
       }
     } catch (NoSourceAvailableException e) {
+      Logger.println(e);
       return;
     }
   }

--- a/src/main/java/com/appland/appmap/transform/annotations/Hook.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/Hook.java
@@ -193,6 +193,9 @@ public class Hook {
           + targetBehavior.getDeclaringClass().getName()
           + "."
           + targetBehavior.getName());
+      Logger.println("  cause: " + e.getCause());
+      Logger.println("  reason: " + e.getReason());
+      
 
       Logger.println(e.getMessage());
     } catch (NotFoundException e) {

--- a/src/main/java/com/appland/appmap/util/Logger.java
+++ b/src/main/java/com/appland/appmap/util/Logger.java
@@ -1,8 +1,13 @@
 package com.appland.appmap.util;
 
+import java.io.PrintStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import com.appland.appmap.config.Properties;
 
 public class Logger {
+  private static PrintStream log = ensureLog();
+  
   public static void println(Exception e) {
     Logger.println(e.getMessage());
   }
@@ -12,7 +17,7 @@ public class Logger {
       return;
     }
 
-    System.err.println("AppMap [DEBUG]: " + msg);
+    log.println("AppMap [DEBUG]: " + msg);
   }
 
   public static void printf(String format, Object... args) {
@@ -20,6 +25,15 @@ public class Logger {
       return;
     }
 
-    System.err.printf("AppMap [DEBUG]: " + format, args);
+    log.printf("AppMap [DEBUG]: " + format, args);
+  }
+
+  private static PrintStream ensureLog() {
+    try {
+      return new PrintStream(new FileOutputStream("appmap-java.log"));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/test/entrypoint
+++ b/test/entrypoint
@@ -1,9 +1,8 @@
 #!/bin/bash
-set -e
+set -x
 
-LOG_FILE=/tmp/output.log
-
-java -javaagent:/appmap.jar -jar /petclinic.jar &> ${LOG_FILE} &
+LOG=/run/petclinic.log
+java -ea -Dappmap.debug -javaagent:/appmap.jar -jar /petclinic.jar &> $LOG &
 JVM_PID=$!
 
 export WS_URL="http://localhost:8080"
@@ -12,7 +11,7 @@ printf 'getting set up'
 while [ -z "$(curl -sI "${WS_URL}" | grep 'HTTP/1.1 200')" ]; do
   if ! kill -0 "${JVM_PID}" 2> /dev/null; then
     printf '. failed!\n\nprocess exited unexpectedly:\n'
-    cat "${LOG_FILE}"
+    cat $LOG
     exit 1
   fi
 
@@ -22,5 +21,9 @@ done
 printf ' ok\n\n'
 
 ${@:-bats --tap /test/*.bats}
+bats_ret=$?
 
 kill ${JVM_PID}
+wait -f ${JVM_PID}
+cat $LOG
+exit $bats_ret


### PR DESCRIPTION
These changes improve the agent so it uses less memory while recording. 

For example, when recording the `jetty-server` tests in https://github.com/land-of-apps/jetty.project, memory usage for v0.4.0 of the agent looks like this:
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/4212483/91043724-1a031280-e5e2-11ea-9ae0-778498b7888c.png">
With these changes, it looks like this:
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/4212483/91043761-28512e80-e5e2-11ea-9e66-299e58a16199.png">
There's still more room for improvement, though. With the agent, memory usage looks like this:
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/4212483/91043828-49b21a80-e5e2-11ea-8111-5f228f030a07.png">

These changes also add support for hooking methods that have been compiled with `-g:vars`. It's currently turned off, though, because enabling it broke the end-to-end tests with petclinic.

Finally, I tried to make logging a bit more useful, and to make it easier to diagnose test failures.