### PR TITLE
Fix classmap generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.1] - 2020-08-25
 ### Added
 - The new system property `appmap.record` can be used to specify a method to record.
-
+- The system property `appmap.debug.file`. When set, debug output will be written to the
+  specified file, instead of to `System.err`.
+  
 ### Changed
 - `appmap-java` now uses significantly less memory when recording.
 

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -8,6 +8,7 @@ public class Properties {
   public static final Boolean Debug = (System.getProperty("appmap.debug") != null);
   public static final Boolean DebugHooks = (System.getProperty("appmap.debug.hooks") != null);
   public static final Boolean DebugLocals = (System.getProperty("appmap.debug.locals") != null);
+  public static final String DebugFile = resolveProperty("appmap.debug.file", (String)null);
 
   public static final String DefaultOutputDirectory = "./tmp/appmap";
   public static final String OutputDirectory = resolveProperty(
@@ -23,7 +24,7 @@ public class Properties {
 
   public static final String[] DefaultRecords = new String[0];
   public static final String[] Records = resolveProperty(
-          "appmap.record", DefaultRecords);
+       "appmap.record", DefaultRecords);
 
   private static String resolveProperty(String propName, String defaultValue) {
     String value = defaultValue;
@@ -61,11 +62,15 @@ public class Properties {
     String[] value = defaultValue;
     try {
       final String propValue = System.getProperty(propName);
-      value = propValue.split(",");
-      assert (value.length < 2);
+      if (propValue != null) {
+        value = propValue.split(",");
+        assert (value.length < 2);
+      }
     } catch (Exception e) {
-      Logger.printf("failed to resolve %s, falling back to default\n", propName);
-      Logger.println(e);
+      // Logger may not be configured yet, so use System.err here to
+      // report problems.
+      System.err.printf("failed to resolve %s, falling back to default\n", propName);
+      e.printStackTrace(System.err);
     }
     return value;
   }

--- a/src/main/java/com/appland/appmap/record/CodeObjectTree.java
+++ b/src/main/java/com/appland/appmap/record/CodeObjectTree.java
@@ -91,20 +91,20 @@ public class CodeObjectTree {
         return null;
       }
       start = end + 1;
-      codeObjects[idx++] = child;
-      currentObject = child;
+      codeObjects[idx++] = currentObject = child;
     }
     assert definedClass.length() - start > 0 : "Not enough tokens";  // Should be one more token
     CodeObject child = currentObject.findChildBySubstring(definedClass, start, definedClass.length());
     if (child == null) {
       return null;
     }
+    codeObjects[idx++] = currentObject = child;
     
     CodeObject methodObject = currentObject.findChild(methodId, isStatic, lineNumber);
     if (methodObject == null) {
       return null;
     }
-    codeObjects[++idx] = methodObject;
+    codeObjects[idx] = methodObject;
 
     CodeObject rootObject = null;
     for (CodeObject codeObject : codeObjects) {

--- a/src/main/java/com/appland/appmap/record/CodeObjectTree.java
+++ b/src/main/java/com/appland/appmap/record/CodeObjectTree.java
@@ -18,16 +18,16 @@ public class CodeObjectTree {
 
   }
 
-  private void add(CodeObject rootObject, ArrayList<CodeObject> newObjects) {
+  private void add(CodeObject rootObject, List<CodeObject> newObjects) {
     for (CodeObject newObject : newObjects) {
       this.add(rootObject, newObject);
     }
   }
 
   private void add(CodeObject rootObject, CodeObject newObject) {
-    for (CodeObject child : rootObject.getChildren()) {
+    for (CodeObject child : rootObject.safeGetChildren()) {
       if (child.equals(newObject)) {
-        this.add(child, newObject.getChildren());
+        this.add(child, newObject.safeGetChildren());
         return;
       }
     }
@@ -129,7 +129,7 @@ public class CodeObjectTree {
    *         {@code false}.
    */
   public Boolean isEmpty() {
-    return this.root == null || this.root.getChildren().size() < 1;
+    return this.root == null || this.root.safeGetChildren().size() < 1;
   }
 
   /**
@@ -137,7 +137,7 @@ public class CodeObjectTree {
    * @return A flattened array of {@link CodeObject}s
    */
   public CodeObject[] toArray() {
-    ArrayList<CodeObject> children = root.getChildren();
+    List<CodeObject> children = root.safeGetChildren();
     Integer numTopLevelObjects = children.size();
     CodeObject[] codeObjects = new CodeObject[numTopLevelObjects];
     for (int i = 0; i < numTopLevelObjects; ++i) {

--- a/src/main/java/com/appland/appmap/record/IRecordingSession.java
+++ b/src/main/java/com/appland/appmap/record/IRecordingSession.java
@@ -17,8 +17,6 @@ public interface IRecordingSession {
 
   public void add(Event event) throws ActiveSessionException;
 
-  public void add(CodeObject codeObject) throws ActiveSessionException;
-
   public void start() throws ActiveSessionException;
 
   public String stop() throws ActiveSessionException;

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -107,16 +107,7 @@ public class Recorder {
       throws ActiveSessionException {
     event.freeze();
 
-    CodeObject rootObject = this.globalCodeObjects.getMethodBranch(event.definedClass,
-          event.methodId,
-          event.isStatic,
-          event.lineNumber);
-
     recordingSession.add(event);
-
-    if (rootObject != null) {
-      recordingSession.add(rootObject);
-    }
   }
 
   /**
@@ -211,6 +202,10 @@ public class Recorder {
     this.globalCodeObjects.add(codeObject);
   }
 
+  public CodeObjectTree getRegisteredObjects() {
+    return this.globalCodeObjects;
+  }
+  
   /**
    * Retrieve the last event recorded.
    */

--- a/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
@@ -83,7 +83,7 @@ public class RecordingSessionFileStream extends RecordingSessionGeneric {
     this.flushEvents();
 
     try {
-      this.serializer.write(this.codeObjects);
+      this.serializer.write(getClassMap());
       this.serializer.finalize();
       this.fileWriter.close();
     } catch (IOException e) {

--- a/src/main/java/com/appland/appmap/record/RecordingSessionGeneric.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionGeneric.java
@@ -2,19 +2,23 @@ package com.appland.appmap.record;
 
 import com.appland.appmap.output.v1.CodeObject;
 import com.appland.appmap.output.v1.Event;
+import com.appland.appmap.util.Logger;
 
 import java.util.Vector;
+import java.util.HashSet;
 
 public class RecordingSessionGeneric implements IRecordingSession {
   protected Vector<Event> events = new Vector<Event>();
-  protected CodeObjectTree codeObjects = new CodeObjectTree();
+  protected HashSet<String> classReferences = new HashSet<>();
 
   public synchronized void add(Event event) {
     this.events.add(event);
-  }
 
-  public synchronized void add(CodeObject codeObject) {
-    this.codeObjects.add(codeObject);
+    final String key = event.definedClass +
+      ":" + event.methodId +
+      ":" + event.isStatic + 
+      ":" + event.lineNumber;
+    this.classReferences.add(key);
   }
 
   public void start() {
@@ -23,5 +27,19 @@ public class RecordingSessionGeneric implements IRecordingSession {
 
   public String stop() {
     throw new UnsupportedOperationException();
+  }
+
+  protected CodeObjectTree getClassMap() {
+    CodeObjectTree registeredObjects = Recorder.getInstance().getRegisteredObjects();
+    CodeObjectTree classMap = new CodeObjectTree();
+    for (String key: this.classReferences) {
+      String[] parts = key.split(":");
+     
+      CodeObject methodBranch = registeredObjects.getMethodBranch(parts[0], parts[1], Boolean.valueOf(parts[2]), Integer.valueOf(parts[3]));
+      if (methodBranch != null)
+        classMap.add(methodBranch);
+    }
+
+    return classMap;
   }
 }

--- a/src/main/java/com/appland/appmap/record/RecordingSessionMemory.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionMemory.java
@@ -31,7 +31,7 @@ public class RecordingSessionMemory extends RecordingSessionGeneric {
     try {
       serializer.write(this.metadata);
       serializer.write(this.events);
-      serializer.write(this.codeObjects);
+      serializer.write(getClassMap());
       serializer.finalize();
 
       json = stringWriter.toString();

--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -128,9 +128,9 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
 
       Hook.apply(behavior, hookSites);
 
-      for (HookSite hookSite : hookSites) {
-        final Hook hook = hookSite.getHook();
-        if (Properties.DebugHooks) {
+      if (Properties.DebugHooks) {
+        for (HookSite hookSite : hookSites) {
+          final Hook hook = hookSite.getHook();
           Logger.printf("hooked %s.%s%s on (%s) with %s\n",
                         behavior.getDeclaringClass().getName(),
                         behavior.getName(),

--- a/src/main/java/com/appland/appmap/util/Logger.java
+++ b/src/main/java/com/appland/appmap/util/Logger.java
@@ -28,12 +28,18 @@ public class Logger {
     log.printf("AppMap [DEBUG]: " + format, args);
   }
 
+  public static void whereAmI() {
+    new Exception().printStackTrace(log);
+  }
+  
   private static PrintStream ensureLog() {
+    final String debugFile = Properties.DebugFile;
     try {
-      return new PrintStream(new FileOutputStream("appmap-java.log"));
+      return debugFile != null? new PrintStream(new FileOutputStream(debugFile)) : System.err;
     }
     catch (IOException e) {
-      throw new RuntimeException(e);
+      System.err.println("AppMap [DEBUG]: Warning, failed opening file: %s. Using System.err instead.\n", e.getMessage());
     }
+    return System.err;
   }
 }

--- a/src/main/java/com/appland/appmap/util/Logger.java
+++ b/src/main/java/com/appland/appmap/util/Logger.java
@@ -38,7 +38,7 @@ public class Logger {
       return debugFile != null? new PrintStream(new FileOutputStream(debugFile)) : System.err;
     }
     catch (IOException e) {
-      System.err.println("AppMap [DEBUG]: Warning, failed opening file: %s. Using System.err instead.\n", e.getMessage());
+      System.err.printf("AppMap [DEBUG]: Warning, failed opening file: %s. Using System.err instead.\n", e.getMessage());
     }
     return System.err;
   }

--- a/src/test/java/com/appland/appmap/record/RecorderTest.java
+++ b/src/test/java/com/appland/appmap/record/RecorderTest.java
@@ -31,9 +31,11 @@ public class RecorderTest {
     for (int i = 0; i < events.length; i++) {
       final Event event = events[i];
       event
-          .setDefinedClass("SomeClass")
-          .setMethodId("SomeMethod")
-          .setThreadId(threadId);
+        .setDefinedClass("SomeClass")
+        .setMethodId("SomeMethod")
+        .setStatic(false)
+        .setLineNumber(315)
+        .setThreadId(threadId);
 
       recorder.add(event);
       assertEquals(event, recorder.getLastEvent());

--- a/test/entrypoint
+++ b/test/entrypoint
@@ -20,10 +20,14 @@ while [ -z "$(curl -sI "${WS_URL}" | grep 'HTTP/1.1 200')" ]; do
 done
 printf ' ok\n\n'
 
-${@:-bats --tap /test/*.bats}
+run_bats() {
+  bats --tap /test/*.bats >bats.log 2>&1
+}
+${@:-run_bats}
 bats_ret=$?
 
 kill ${JVM_PID}
 wait -f ${JVM_PID}
 cat $LOG
+cat bats.log
 exit $bats_ret

--- a/test/helper.bash
+++ b/test/helper.bash
@@ -23,8 +23,11 @@ print_debug() {
   local result="${2}"
 
   if [[ ! -z "${DEBUG_JSON}" ]]; then
+    echo >&3
     echo "${output}" >&3
-    "result: ${result}" >&3
+    echo >&3
+    echo "result: ${result}" >&3
+    echo >&3
   fi
 }
 

--- a/test/smoke.bats
+++ b/test/smoke.bats
@@ -110,7 +110,7 @@ load 'helper'
   assert_json_contains '.events[] | .message' 'petId'
 }
 
-@test "expected number of events captured" {
+@test "expected appmap captured" {
   start_recording
   
   # this route seems least likely to be affected by future changes
@@ -118,5 +118,10 @@ load 'helper'
   
   stop_recording
 
+  # Sanity check the events and classmap
   assert_json_eq '.events | length' 6
+
+  assert_json_eq '.classMap | length' 2
+  assert_json_eq '[.classMap[0] | recurse | .name?] | join(".")' javax.servlet.http.HttpServlet.service
+  assert_json_eq '[.classMap[1] | recurse | .name?] | join(".")' org.springframework.samples.petclinic.system.CrashController.triggerException
 }


### PR DESCRIPTION
See additional comments on the individual commits for more details of these changes. Might be easiest to review them one by one.

Memory usage in 0.4.0 for the jetty-server submodule in land-of-apps/jetty.project:
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/4212483/91488507-65851d00-e87d-11ea-91bd-21d1a6d35922.png">

Memory usage now:
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/4212483/91488563-77ff5680-e87d-11ea-9b04-9af213acd660.png">
