### PR TITLE
Add some logging, clean up some uses of reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.4.2] - 2020-10-06
+### Added
+- The new system property `appmap.debug.http` to show some debugging when handling
+  requests for `/_appmap/record`.
+  
+### Changed
+- Cleaned up reflection in `HttpServletRequest`, `HttpServletResponse`, and `FilterChain`.
+  
 ## [0.4.1] - 2020-08-25
 ### Added
 - The new system property `appmap.record` can be used to specify a method to record.

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.4.1'
+version = '0.4.2'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -9,6 +9,7 @@ public class Properties {
   public static final Boolean DebugHooks = (System.getProperty("appmap.debug.hooks") != null);
   public static final Boolean DebugLocals = (System.getProperty("appmap.debug.locals") != null);
   public static final String DebugFile = resolveProperty("appmap.debug.file", (String)null);
+  public static final Boolean DebugHttp = System.getProperty("appmap.debug.http") != null;
 
   public static final String DefaultOutputDirectory = "./tmp/appmap";
   public static final String OutputDirectory = resolveProperty(

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -1,5 +1,6 @@
 package com.appland.appmap.process.hooks;
 
+import com.appland.appmap.config.Properties;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.process.ExitEarly;
 import com.appland.appmap.process.conditions.RecordCondition;
@@ -21,10 +22,15 @@ import static com.appland.appmap.util.StringUtil.*;
  * Hooks to toggle event recording. This could be either via HTTP or by entering a unit test method.
  */
 public class ToggleRecord {
+  private static boolean debug = Properties.DebugHttp;
   private static final Recorder recorder = Recorder.getInstance();
   public static final String RecordRoute = "/_appmap/record";
 
   private static void doDelete(HttpServletRequest req, HttpServletResponse res) {
+    if (debug) {
+      Logger.println("ToggleRecord.doDelete");
+    }
+
     try {
       String json = recorder.stop();
       res.setContentType("application/json");
@@ -41,6 +47,10 @@ public class ToggleRecord {
   }
 
   private static void doGet(HttpServletRequest req, HttpServletResponse res) {
+    if (debug) {
+      Logger.println("ToggleRecord.doGet");
+    }
+
     res.setStatus(HttpServletResponse.SC_OK);
 
     String responseJson = String.format("{\"enabled\":%b}", recorder.hasActiveSession());
@@ -57,6 +67,10 @@ public class ToggleRecord {
   }
 
   private static void doPost(HttpServletRequest req, HttpServletResponse res) {
+    if (debug) {
+      Logger.println("ToggleRecord.doPost");
+    }
+
     IRecordingSession.Metadata metadata = new IRecordingSession.Metadata();
     metadata.recorderName = "remote_recording";
     try {
@@ -76,6 +90,10 @@ public class ToggleRecord {
       return;
     }
 
+    if (debug) {
+      Logger.println("ToggleRecord.service - handling appmap request");
+    }
+
     final HttpServletResponse res = new HttpServletResponse(args[1]);
     if (req.getMethod().equals("GET")) {
       doGet(req, res);
@@ -85,11 +103,18 @@ public class ToggleRecord {
       doDelete(req, res);
     }
 
+    if (debug) {
+      Logger.println("ToggleRecord.service - successfully handled appmap request, exiting early");
+    }
+
     throw new ExitEarly();
   }
 
   private static void skipFilterChain(Object[] args) throws ExitEarly {
     if (args.length != 3) {
+      if (debug) {
+        Logger.println("ToggleRecord.skipFilterChain - invalid arg length");
+      }
       return;
     }
 
@@ -98,8 +123,16 @@ public class ToggleRecord {
       return;
     }
 
+    if (debug) {
+      Logger.println("ToggleRecord.skipFilterChain - skipping filter chain");
+    }
+
     final FilterChain chain = new FilterChain(args[2]);
     chain.doFilter(args[0], args[1]);
+
+    if (debug) {
+      Logger.println("ToggleRecord.skipFilterChain - successfully skipped, exiting early");
+    }
 
     throw new ExitEarly();
   }

--- a/src/main/java/com/appland/appmap/reflect/FilterChain.java
+++ b/src/main/java/com/appland/appmap/reflect/FilterChain.java
@@ -5,25 +5,19 @@ import java.lang.reflect.Method;
 import com.appland.appmap.util.Logger;
 
 public class FilterChain extends ReflectiveType {
-  private static Method fnDoFilter;
+  private Method fnDoFilter;
 
   public FilterChain(Object self) {
     super(self);
 
-    if (fnDoFilter == null) {
-      fnDoFilter = this.getMethod("doFilter",
-          "javax.servlet.ServletRequest",
-          "javax.servlet.ServletResponse");
-    }
+    fnDoFilter = getMethodByClassNames("doFilter",
+                                       "javax.servlet.ServletRequest",
+                                       "javax.servlet.ServletResponse");
   }
 
   public void doFilter(Object request, Object response) {
     if (fnDoFilter != null) {
-      try {
-        fnDoFilter.invoke(this.self, request, response);
-      } catch (Exception e) {
-        Logger.printf("failed to invoke method doFilter: %s", e.getMessage());
-      }
+      invoke(fnDoFilter, request, response);
     }
   }
 }

--- a/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
+++ b/src/main/java/com/appland/appmap/reflect/HttpServletRequest.java
@@ -5,92 +5,41 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class HttpServletRequest extends ReflectiveType {
-  private static Method fnGetMethod;
-  private static Method fnGetRequestURI;
-  private static Method fnGetProtocol;
-  private static Method fnGetParameterMap;
+  private Method fnGetMethod;
+  private Method fnGetRequestURI;
+  private Method fnGetProtocol;
+  private Method fnGetParameterMap;
 
   public HttpServletRequest(Object self) {
     super(self);
 
-    if (fnGetMethod == null) {
-      try {
-        fnGetMethod = this.self.getClass().getMethod("getMethod");
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnGetRequestURI == null) {
-      try {
-        fnGetRequestURI = this.self.getClass().getMethod("getRequestURI");
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnGetProtocol == null) {
-      try {
-        fnGetProtocol = this.self.getClass().getMethod("getProtocol");
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnGetParameterMap == null) {
-      try {
-        fnGetParameterMap = this.self.getClass().getMethod("getParameterMap");
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
+    fnGetMethod = getMethod("getMethod");
+    fnGetRequestURI = getMethod("getRequestURI");
+    fnGetProtocol = getMethod("getProtocol");
+    fnGetParameterMap = getMethod("getParameterMap");
   }
 
   public String getMethod() {
-    if (fnGetMethod != null) {
-      try {
-        return (String) fnGetMethod.invoke(this.self);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    return "";
+    return fnGetMethod != null?
+      (String)invoke(fnGetMethod)
+      : "";
   }
 
   public String getRequestURI() {
-    if (fnGetRequestURI != null) {
-      try {
-        return (String) fnGetRequestURI.invoke(this.self);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    return "";
+    return fnGetRequestURI != null?
+      (String)invoke(fnGetRequestURI)
+      : "";
   }
 
   public String getProtocol() {
-    if (fnGetProtocol != null) {
-      try {
-        return (String) fnGetProtocol.invoke(this.self);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    return "";
+    return fnGetProtocol != null?
+      (String)invoke(fnGetProtocol)
+      : "";
   }
 
   public Map<String, String[]> getParameterMap() {
-    if (fnGetProtocol != null) {
-      try {
-        return (Map<String, String[]>) fnGetParameterMap.invoke(this.self);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    return new HashMap<String, String[]>();
+    return fnGetProtocol != null?
+      (Map<String, String[]>)invoke(fnGetParameterMap)
+      : new HashMap<String, String[]>();
   }
 }

--- a/src/main/java/com/appland/appmap/reflect/HttpServletResponse.java
+++ b/src/main/java/com/appland/appmap/reflect/HttpServletResponse.java
@@ -9,128 +9,57 @@ public class HttpServletResponse extends ReflectiveType {
   public static final int SC_NOT_FOUND = 404;
   public static final int SC_OK = 200;
 
-  private static Method fnSetContentType;
-  private static Method fnSetContentLength;
-  private static Method fnSetStatus;
-  private static Method fnGetWriter;
-  private static Method fnGetStatus;
-  private static Method fnGetContentType;
+  private Method fnSetContentType;
+  private Method fnSetContentLength;
+  private Method fnSetStatus;
+  private Method fnGetWriter;
+  private Method fnGetStatus;
+  private Method fnGetContentType;
 
   public HttpServletResponse(Object self) {
     super(self);
 
-    if (fnSetContentType == null) {
-      try {
-        fnSetContentType = this.self.getClass().getMethod("setContentType", String.class);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnSetContentLength == null) {
-      try {
-        fnSetContentLength = this.self.getClass().getMethod("setContentLength", int.class);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnSetStatus == null) {
-      try {
-        fnSetStatus = this.self.getClass().getMethod("setStatus", int.class);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnGetWriter == null) {
-      try {
-        fnGetWriter = this.self.getClass().getMethod("getWriter");
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnGetStatus == null) {
-      try {
-        fnGetStatus = this.self.getClass().getMethod("getStatus");
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    if (fnGetContentType == null) {
-      try {
-        fnGetContentType = this.self.getClass().getMethod("getContentType");
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
+    fnSetContentType = getMethod("setContentType", String.class);
+    fnSetContentLength = getMethod("setContentLength", int.class);
+    fnSetStatus = getMethod("setStatus", int.class);
+    fnGetWriter = getMethod("getWriter");
+    fnGetStatus = getMethod("getStatus");
+    fnGetContentType = getMethod("getContentType");
   }
 
   public void setContentType(String type) {
     if (fnSetContentType != null) {
-      try {
-        fnSetContentType.invoke(this.self, type);
-      } catch (Exception e) {
-        /* log an error */
-      }
+      invoke(fnSetContentType, type);
     }
   }
 
   public void setContentLength(int len) {
     if (fnSetContentLength != null) {
-      try {
-        fnSetContentLength.invoke(this.self, len);
-      } catch (Exception e) {
-        /* log an error */
-      }
+      invoke(fnSetContentLength, len);
     }
   }
 
   public void setStatus(int sc) {
     if (fnSetStatus != null) {
-      try {
-        fnSetStatus.invoke(this.self, sc);
-      } catch (Exception e) {
-        /* log an error */
-      }
+      invoke(fnSetStatus, sc);
     }
   }
 
   public PrintWriter getWriter() throws IOException {
-    if (fnGetWriter != null) {
-      try {
-        return (PrintWriter) fnGetWriter.invoke(this.self);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    return null;
+    return fnGetWriter != null?
+      (PrintWriter)invoke(fnGetWriter)
+      : null;
   }
 
   public int getStatus() {
-    if (fnGetStatus != null) {
-      try {
-        return (int) fnGetStatus.invoke(this.self);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    return -1;
+    return fnGetStatus != null?
+      (int)invoke(fnGetStatus)
+      : -1;
   }
 
   public String getContentType() {
-    if (fnGetContentType != null) {
-      try {
-        return (String) fnGetContentType.invoke(this.self);
-      } catch (Exception e) {
-        /* log an error */
-      }
-    }
-
-    return "";
+    return fnGetContentType != null?
+      (String)invoke(fnGetContentType)
+      : "";
   }
 }

--- a/src/main/java/com/appland/appmap/reflect/ReflectiveType.java
+++ b/src/main/java/com/appland/appmap/reflect/ReflectiveType.java
@@ -1,6 +1,7 @@
 package com.appland.appmap.reflect;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
 
 import com.appland.appmap.util.Logger;
 
@@ -11,17 +12,30 @@ public class ReflectiveType {
     this.self = self;
   }
 
-  public Object GetObject() {
-    return this.self;
-  }
-
   protected Method getMethod(String name, Class<?>... parameterTypes) {
+    final Class cls = self.getClass();
     try {
-      return this.self.getClass().getMethod(name, parameterTypes);
+      return cls.getMethod(name, parameterTypes);
     } catch (Exception e) {
-      Logger.printf("failed to get method %s: %s\n", name, e.getMessage());
+      Logger.printf("failed to get method %s.%s: %s\n", cls.getName(), name, e.getMessage());
       return null;
     }
+  }
+
+  protected Object invoke(Method method, Object... parameters) {
+    try {
+      return method.invoke(self, parameters);
+    }
+    catch (InvocationTargetException e) {
+      Throwable thrown = e.getTargetException();
+      final String msg = String.format("%s.%s threw an exception, %s\n", self.getClass().getName(), method.getName(), thrown != null? thrown.getMessage() : "<no msg>");
+      Logger.println(msg);
+      throw new Error(msg, thrown);
+    }
+    catch (Exception e) {
+      Logger.printf("failed invoking %s.%s, %s\n", self.getClass().getName(), method.getName(), e.getMessage());
+    }
+    return null;
   }
 
   /**
@@ -30,7 +44,7 @@ public class ReflectiveType {
    * @param parameterTypes Fully qualified class names of all parameters
    * @return Matching method if found. Otherwise, null.
    */
-  protected Method getMethod(String name, String... parameterTypes) {
+  protected Method getMethodByClassNames(String name, String... parameterTypes) {
     Method[] methods;
 
     try {

--- a/src/main/java/com/appland/appmap/web/RecordServlet.java
+++ b/src/main/java/com/appland/appmap/web/RecordServlet.java
@@ -4,6 +4,7 @@ import com.appland.appmap.record.ActiveSessionException;
 import com.appland.appmap.record.IRecordingSession;
 import com.appland.appmap.record.Recorder;
 import com.appland.appmap.util.Logger;
+import com.appland.appmap.config.Properties;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -15,9 +16,14 @@ import java.io.PrintWriter;
 @WebServlet(name = "RecordServlet", urlPatterns = {"/_appmap/record"}, loadOnStartup = 1) 
 public class RecordServlet extends HttpServlet {
   private static final Recorder recorder = Recorder.getInstance();
+  private static boolean debug = Properties.DebugHttp;
 
   @Override
   protected void doDelete(HttpServletRequest req, HttpServletResponse res) {
+    if (debug) {
+      Logger.println("RecordServlet.doDelete");
+    }
+
     try {
       String json = recorder.stop();
       res.setContentType("application/json");
@@ -35,6 +41,10 @@ public class RecordServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse res) {
+    if (debug) {
+      Logger.println("RecordServlet.doGet");
+    }
+
     res.setStatus(HttpServletResponse.SC_OK);
 
     String responseJson = String.format("{\"enabled\":%b}", recorder.hasActiveSession());
@@ -52,6 +62,10 @@ public class RecordServlet extends HttpServlet {
 
   @Override
   protected void doPost(HttpServletRequest req, HttpServletResponse res) {
+    if (debug) {
+      Logger.println("RecordServlet.doPost");
+    }
+
     IRecordingSession.Metadata metadata = new IRecordingSession.Metadata();
     metadata.recorderName = "remote_recording";
     try {


### PR DESCRIPTION
Added the new system property `appmap.debug.http` to show some debugging when handling requests for `/_appmap/record`.

Cleaned up reflection in `HttpServletRequest`, `HttpServletResponse`, and `FilterChain`.

