### PR TITLE
Make method accessible before invoking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## [0.4.2] - 2020-10-06
+## [0.4.3] - 2020-10-08
+### Fixed
+- ReflectiveType.invoke now makes the method accessible before trying to invoke it.
+
+## [0.4.2] - 2020-10-06 (yanked)
 ### Added
 - The new system property `appmap.debug.http` to show some debugging when handling
   requests for `/_appmap/record`.

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
   mavenCentral()
 }
 
-version = '0.4.2'
+version = '0.4.3'
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'

--- a/src/main/java/com/appland/appmap/reflect/ReflectiveType.java
+++ b/src/main/java/com/appland/appmap/reflect/ReflectiveType.java
@@ -24,6 +24,7 @@ public class ReflectiveType {
 
   protected Object invoke(Method method, Object... parameters) {
     try {
+      method.setAccessible(true);
       return method.invoke(self, parameters);
     }
     catch (InvocationTargetException e) {


### PR DESCRIPTION
ReflectiveType.invoke needs to make the method accessible before trying
to invoke it.