### PR TITLE
Add instructions for external contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ We are incredibly thankful for the contributions we receive from the community. 
 ## Contributor License Agreement
 We require our external contributors to sign a Contributor License Agreement ("CLA") in order to ensure that
 our projects remain licensed under Free and Open Source licenses such as while allowing
-Appland to build a sustainable business.
+AppLand to build a sustainable business.
 
-Appland is committed to having a true Free and Open Source Software license for our
+AppLand is committed to having a true Free and Open Source Software license for our
 non-commercial software. A CLA enables AppLand to safely commercialize our products while
 keeping a standard FOSS license with all the rights that license grants to users.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to appmap-java
+
+We are incredibly thankful for the contributions we receive from the community. Before contributing, please take a moment to read our [Contributor License Agreement](https://github.com/applandorg/community/blob/master/docs/CLA%20Instructions.pdf) and our [Code of Conduct](https://github.com/applandorg/community/blob/master/docs/Code%20of%20Conduct%20for%20Contributors.pdf).
+
+## Contributor License Agreement
+We require our external contributors to sign a Contributor License Agreement ("CLA") in order to ensure that
+our projects remain licensed under Free and Open Source licenses such as while allowing
+Appland to build a sustainable business.
+
+Appland is committed to having a true Free and Open Source Software license for our
+non-commercial software. A CLA enables AppLand to safely commercialize our products while
+keeping a standard FOSS license with all the rights that license grants to users.
+
+ * [Contributor License Agreement](https://github.com/applandorg/community/blob/master/docs/CLA%20Instructions.pdf)
+
+
+## Code of Conduct
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and
+healthy community.
+
+ * [Code of Conduct](https://github.com/applandorg/community/blob/master/docs/Code%20of%20Conduct%20for%20Contributors.pdf)


### PR DESCRIPTION
The CONTRIBUTING.md references AppLand Contributor License Agreement and Code of Conduct.