### PR TITLE
Support publication of AppMapAgent to OSSRH repo 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,20 @@ script:
 - ./gradlew -is integrationTest
 - ./bin/test
 deploy:
-  provider: releases
-  api_key:
-    secure: VklliU5eYog7dVHMdj0py4fzeec8JjOm5zfLdKlcyeJqNeSe5tYjcdKkbwrdBA9BjCRaw2AnplgAnFU2t6FK0eHEVO5uezIn3fU/YM3BM97hJITI+4jl6XA4Af50xGkuY7g4qrhCxVtpJ8bWlVB7JwbA4zABxnkrttsSRSQqydZI2q9G3hsiV6wkiJKMLCFSCttR4xCnrENXypO6QLxBqv/9jEhbNEm/oe8mj9fXSz5zKz8KfSIIGELxYSK/MM/iAA12htVSXxk6NdKwDCKEWXbkDzz1rYwoQfH67mY8TSvQ216Tibf+4BCId6FbSV9m0Z+OISzRVsa/ABQMz2NRm7lyQbS8zBMYvrkE0H7qO8hugb75+cmXYu4K0utcTmFzqnxw8U8lDgrbBXpsb/8rz7jDKpRhueTupoCD7NexEXp/ZRr9U3N+NoyG7S55BYlO+U0rWmmMaywE3EsT8z+s+FSltfAcfDhyFjm0Xn3DUxwjsD8WhQwCT4x+5Rv8AKSU3qTGFZlbD0T8iMbZzPrQe/ElywRBJU+C6LI65h63UI14ePyrVgENdFcQvN7QkLigU0n3PTo+xgEO1e/3zk4jK/IcZzaxZ83nMuqce68xpGj8qTmPLkTSeE6KUFKKfhlyk8kiRCLmFP11Rb9PEh9VzpWRWAw/aird2E0+RO+nD/U=
-  file_glob: true
-  file:
-  - build/libs/appmap-*-java*.jar
-  skip_cleanup: true
-  on:
-    tags: true
+  - provider: releases
+    api_key:
+      secure: VklliU5eYog7dVHMdj0py4fzeec8JjOm5zfLdKlcyeJqNeSe5tYjcdKkbwrdBA9BjCRaw2AnplgAnFU2t6FK0eHEVO5uezIn3fU/YM3BM97hJITI+4jl6XA4Af50xGkuY7g4qrhCxVtpJ8bWlVB7JwbA4zABxnkrttsSRSQqydZI2q9G3hsiV6wkiJKMLCFSCttR4xCnrENXypO6QLxBqv/9jEhbNEm/oe8mj9fXSz5zKz8KfSIIGELxYSK/MM/iAA12htVSXxk6NdKwDCKEWXbkDzz1rYwoQfH67mY8TSvQ216Tibf+4BCId6FbSV9m0Z+OISzRVsa/ABQMz2NRm7lyQbS8zBMYvrkE0H7qO8hugb75+cmXYu4K0utcTmFzqnxw8U8lDgrbBXpsb/8rz7jDKpRhueTupoCD7NexEXp/ZRr9U3N+NoyG7S55BYlO+U0rWmmMaywE3EsT8z+s+FSltfAcfDhyFjm0Xn3DUxwjsD8WhQwCT4x+5Rv8AKSU3qTGFZlbD0T8iMbZzPrQe/ElywRBJU+C6LI65h63UI14ePyrVgENdFcQvN7QkLigU0n3PTo+xgEO1e/3zk4jK/IcZzaxZ83nMuqce68xpGj8qTmPLkTSeE6KUFKKfhlyk8kiRCLmFP11Rb9PEh9VzpWRWAw/aird2E0+RO+nD/U=
+    file_glob: true
+    file:
+    - build/libs/appmap-*-java*.jar
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: applandinc/appmap-java 
+  - provider: script
+    script: ./gradlew publish
+    skip_cleanup: true
+    on:
+      all_branches: true
+      tags: true
+      condition: ^[[:digit:]]+\.[[:digit:]]\..*$

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 dist: bionic
 jdk:
 - openjdk8
-- openjdk11
+#- openjdk11
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/CI-README.md
+++ b/CI-README.md
@@ -2,11 +2,11 @@
 
 
 1. Every release master (person allowed to manage releases), should do following:
-1.1. Generate GPG pair for signing releases (please use password protection!)
-See [Guide 1](https://www.gnupg.org/gph/en/manual/c14.html)  
-also [Guide 2](https://www.redhat.com/sysadmin/creating-gpg-keypairs) 
-1.2 Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`
-1.3. [Register sonatype account](https://issues.sonatype.org/secure/Signup!default.jspa)  
+    1.1. Generate GPG pair for signing releases (please use password protection!)
+        See [Guide 1](https://www.gnupg.org/gph/en/manual/c14.html)  
+        also [Guide 2](https://www.redhat.com/sysadmin/creating-gpg-keypairs) 
+    1.2 Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`
+    1.3. [Register sonatype account](https://issues.sonatype.org/secure/Signup!default.jspa)  
 2. The same operations (sonatype account and published GPG identity) should be done for CI bot (please create password-protected key, as suggested by default)
 3. [Create a New Project ticket, requesting new project/namespace to be created.](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134)
 Mention all release masters and CI bot in a list of collaborators.

--- a/CI-README.md
+++ b/CI-README.md
@@ -1,0 +1,107 @@
+﻿# Prerequisites
+
+
+1. Every release master (person allowed to manage releases), should do following:
+    1.1. Generate GPG pair for signing releases (please use password protection!)
+[1](https://www.gnupg.org/gph/en/manual/c14.html) 
+[2](https://www.redhat.com/sysadmin/creating-gpg-keypairs) 
+    1.2 Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`
+    1.3. [Register sonatype account](https://issues.sonatype.org/secure/Signup!default.jspa)  
+2. The same operations (sonatype account and published GPG identity) should be done for CI bot (please create password-protected key, as suggested by default)
+3. [Create a New Project ticket, requesting new project/namespace to be created.](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134)
+Mention all release masters and CI bot in a list of collaborators.
+4. For CI bot, generate travis-compatible version of the GPG key : 
+`cat secret_key.ascii.gpg | python bin/multiline_input_to_travis_env.py > /tmp/travis_compatible_env_value.txt`
+5. At least one account on https://hub.docker.com is needed, which credentials will be used to avoid hitting limits for anonymous docker pulls, often exceeded by Travis servers.
+It is recommended to use separate CI robot account for security purposes, as credentials would be stored (encrypted) on Travis side.
+ 
+# Configuration
+## Travis 
+Following environment variables need to be configured on a repository level:
+1. `DOCKERHUB_USERNAME` _(visible)_ – any Docker Hub account, preferably CI bot’s.
+2. `DOCKERHUB_PASSWORD` _(secret)_
+3. `ORG_GRADLE_PROJECT_ossrhUsername` _(visible)_ – Sonatype username for CI bot
+4. `ORG_GRADLE_PROJECT_ossrhPassword` _(secret)_
+5. `ORG_GRADLE_PROJECT_signingKey` _(secret)_ – the exact contents of CI bot’s GPG key in a form suitable for Travis environment (`/tmp/travis_compatible_env_value.txt`, generated above)
+6. `ORG_GRADLE_PROJECT_signingPassword` _(secret)_ -- passphrase for bot's GPG key
+7. `ORG_GRADLE_PROJECT_publishGroupId` _(optional, visible)_ – if releasing to the Maven namespace different from default `com.appland` 
+
+## Developer environment  
+
+Export variable `TRAVIS_BUILD` setting its value to the desired version number 
+(or change hardcoded `defaultVersion` in a `build.gradle`) .
+
+Export all variables listed in Travis configuration section except 
+`DOCKERHUB_USERNAME`, `DOCKERHUB_PASSWORD`. 
+
+For the variable `ORG_GRADLE_PROJECT_signingKey` use actual multiline key body 
+(depending on your environment, setting up multiline variables could be 
+challenging or not) . 
+
+Following bash expression could be used to set up multiline variable in bash:
+ 
+```
+export  ORG_GRADLE_PROJECT_signingKey=<EXACT CONTENT OF /tmp/travis_compatible_env_value.txt>
+```
+
+Also, every variable which name starts with `ORG_GRADLE_PROJECT_<varname>` 
+could be instead configured as gradle setting `<varname>` (prefix stripped)
+
+
+If you omit `ossrhUsername` setting, publishing would be done locally into 
+directory  `buid/repo`
+
+If you omit `sighingKey` setting, signatures won’t be generated
+
+# Artifacts
+
+The default artifact name base (`appMapAgent`) could be changed 
+via variable `ORG_GRADLE_PROJECT_publishArtifactId`
+
+Gradle adds suffix `java8` or `java11` to the artifact name base 
+in order to derive resulting artifact id.
+ 
+
+# Publishing 
+
+## Manual 
+
+`./gradlew publish`
+
+## Travis 
+
+Maven publication is triggered by semantic-versioned tags in the form `x.y.z`, 
+`x.y.z-whatever` (releases) or `x.y.z-SNAPSHOT` (snapshots)
+
+# Releases
+
+Follow the steps in 
+[Official guide](https://central.sonatype.org/pages/releasing-the-deployment.html) 
+to manually close-validate-release the repository after successful publication.
+
+*After first release in the namespace happens, do not forget to comment on the 
+OSSRH ticket which was used to claim the namespace.*
+
+# Backlog
+
+## Done
+
+
+* Generate Source Jar
+* Generate JavaDoc Jar
+* Publish to local repo
+* Sign artifacts
+* Plug together signing and publishing
+* Fill POM metadata according to Maven requirements
+* Parameterizable coordinates (version, group, artifact)
+* Support Java8
+* Release into real (remote, sonatype) repo
+* BUG: POM contains prohibited syntax for mockito dependency
+* Automate via Travis
+* Regresion in Java8 test
+
+
+## TODO:
+
+* Support release cycle for appmap-java-maven-plugin
+* BUG? Javadoc is intentionally empty due to errors in javadoc generation.

--- a/CI-README.md
+++ b/CI-README.md
@@ -3,14 +3,14 @@
 
 1. Every release master (person allowed to manage releases), should do following:
     1.1. Generate GPG pair for signing releases (please use password protection!)
-[1](https://www.gnupg.org/gph/en/manual/c14.html) 
-[2](https://www.redhat.com/sysadmin/creating-gpg-keypairs) 
-    1.2 Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`
-    1.3. [Register sonatype account](https://issues.sonatype.org/secure/Signup!default.jspa)  
+See [Guide 1](https://www.gnupg.org/gph/en/manual/c14.html)  
+also [Guide 2](https://www.redhat.com/sysadmin/creating-gpg-keypairs) 
+1.2 Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`
+1.3. [Register sonatype account](https://issues.sonatype.org/secure/Signup!default.jspa)  
 2. The same operations (sonatype account and published GPG identity) should be done for CI bot (please create password-protected key, as suggested by default)
 3. [Create a New Project ticket, requesting new project/namespace to be created.](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134)
 Mention all release masters and CI bot in a list of collaborators.
-4. For CI bot, generate travis-compatible version of the GPG key : 
+4. For CI bot, generate travis-compatible version of the GPG key (use gpg2 to export ascii-armored secret key into the file first) : 
 `cat secret_key.ascii.gpg | python bin/multiline_input_to_travis_env.py > /tmp/travis_compatible_env_value.txt`
 5. At least one account on https://hub.docker.com is needed, which credentials will be used to avoid hitting limits for anonymous docker pulls, often exceeded by Travis servers.
 It is recommended to use separate CI robot account for security purposes, as credentials would be stored (encrypted) on Travis side.
@@ -22,7 +22,7 @@ Following environment variables need to be configured on a repository level:
 2. `DOCKERHUB_PASSWORD` _(secret)_
 3. `ORG_GRADLE_PROJECT_ossrhUsername` _(visible)_ – Sonatype username for CI bot
 4. `ORG_GRADLE_PROJECT_ossrhPassword` _(secret)_
-5. `ORG_GRADLE_PROJECT_signingKey` _(secret)_ – the exact contents of CI bot’s GPG key in a form suitable for Travis environment (`/tmp/travis_compatible_env_value.txt`, generated above)
+5. `ORG_GRADLE_PROJECT_signingKey` _(secret)_ – the exact contents of CI bot’s GPG key in a form suitable for Travis environment ( content of `/tmp/travis_compatible_env_value.txt`, generated above)
 6. `ORG_GRADLE_PROJECT_signingPassword` _(secret)_ -- passphrase for bot's GPG key
 7. `ORG_GRADLE_PROJECT_publishGroupId` _(optional, visible)_ – if releasing to the Maven namespace different from default `com.appland` 
 
@@ -55,11 +55,9 @@ If you omit `sighingKey` setting, signatures won’t be generated
 
 # Artifacts
 
-The default artifact name base (`appMapAgent`) could be changed 
+The default artifact name base (`appmap-agent`) could be changed 
 via variable `ORG_GRADLE_PROJECT_publishArtifactId`
 
-Gradle adds suffix `java8` or `java11` to the artifact name base 
-in order to derive resulting artifact id.
  
 
 # Publishing 

--- a/CI-README.md
+++ b/CI-README.md
@@ -2,7 +2,7 @@
 
 
 1. Every release master (person allowed to manage releases), should do following:
-    1.1. Generate GPG pair for signing releases (please use password protection!)
+1.1. Generate GPG pair for signing releases (please use password protection!)
 See [Guide 1](https://www.gnupg.org/gph/en/manual/c14.html)  
 also [Guide 2](https://www.redhat.com/sysadmin/creating-gpg-keypairs) 
 1.2 Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`

--- a/bin/multiline_input_to_travis_env.py
+++ b/bin/multiline_input_to_travis_env.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+# converts multiline stdin into a form suitable for setting env vars in Travis UI
+# see https://github.com/travis-ci/travis-ci/issues/7715#issuecomment-362536708
+
+import sys
+
+body=sys.stdin.read() 
+body = body.replace('\n','\\n')
+body = '"$( echo -e '+"'"+body+"'"+')"'
+print(body)

--- a/bin/test
+++ b/bin/test
@@ -3,6 +3,11 @@
 # run smoke tests
 set -e
 
+# see https://blog.travis-ci.com/docker-rate-limits
+if [ ! -z "$DOCKERHUB_PASSWORD" ] && [ ! -z "$DOCKERHUB_USERNAME" ]; then
+    echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin 
+fi
+
 JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\.//'| cut -d'.' -f1)
 
 if [ $JAVA_VERSION -lt "9" ]; then
@@ -24,8 +29,9 @@ docker build \
   -f $CONFIG \
   .
 
+
 printf '\n=== begin tests ===\n'
-docker run -i $(tty -s && echo '-t') \
+exec docker run -i $(tty -s && echo '-t') \
   --rm \
   "${IMAGE_NAME}:${IMAGE_TAG}" \
   "${@:-/sbin/entrypoint}"

--- a/build.gradle
+++ b/build.gradle
@@ -255,8 +255,8 @@ publishing {
 
         def local_url       = "file://${buildDir}/repo"
         // see https://central.sonatype.org/pages/gradle.html
-        //def default_base        = "https://s01.oss.sonatype.org"
-        def default_base    = "https://oss.sonatype.org"
+        def default_base        = "https://s01.oss.sonatype.org"
+        //def default_base    = "https://oss.sonatype.org"
         def url_base        = findProperty("mavenRepoURL") ?: default_base
         def staging_url     = url_base + "/service/local/staging/deploy/maven2/"
         def snapshots_url   = url_base + "/content/repositories/snapshots/"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def defaultGitSlug="applandinc/appmap-java"
 def currentGitSlug=System.getenv("TRAVIS_REPO_SLUG") ?: defaultGitSlug
 
 def defaultGroupId      = 'com.appland'
-def defaultArtifactId   = 'appMapAgent' 
+def defaultArtifactId   = 'appmap-agent' 
 def publishGroupId      = findProperty('publishGroupId') ?: defaultGroupId 
 def publishArtifactId   = findProperty('publishArtifactId') ?: defaultArtifactId
 
@@ -200,7 +200,7 @@ publishing {
    
                  
             groupId     publishGroupId
-            artifactId  publishArtifactId + '-' + versionSuffix
+            artifactId  publishArtifactId //+ '-' + versionSuffix
     
             // version defined globally
  

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
   id 'java'
   id 'war'
   id 'jacoco'
+  id 'signing'
 }
 
 repositories {
@@ -20,7 +21,24 @@ repositories {
   mavenCentral()
 }
 
-version = '0.5.0'
+// hardcoded -- could be redefined via env variables and project properties (see below)
+def parameterizedVersion    = findProperty('appMapAgentVersion')
+def travisVersion           = System.getenv("TRAVIS_BRANCH") 
+def hardcodedVersion        = '0.5.0'
+
+def versionLikeRegexp       = /^\d+\.\d+.*/
+def travisVersionValid      = travisVersion && (travisVersion ==~ versionLikeRegexp)
+
+
+version = parameterizedVersion ?: ( travisVersionValid ? travisVersion : hardcodedVersion )
+
+def defaultGitSlug="applandinc/appmap-java"
+def currentGitSlug=System.getenv("TRAVIS_REPO_SLUG") ?: defaultGitSlug
+
+def defaultGroupId      = 'com.appland'
+def defaultArtifactId   = 'appMapAgent' 
+def publishGroupId      = findProperty('publishGroupId') ?: defaultGroupId 
+def publishArtifactId   = findProperty('publishArtifactId') ?: defaultArtifactId
 
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'
@@ -30,10 +48,21 @@ dependencies {
   implementation 'javax.servlet:javax.servlet-api:4.0.1'
   implementation 'org.apache.commons:commons-lang3:3.10'
   implementation 'org.slf4j:slf4j-nop:1.7.30'
+ 
+  /* 
+  /// are test classes becoming part of "build" purposedly or by mistake?
+  implementation 'junit:junit:4.12'
+  implementation 'com.github.stefanbirkner:system-rules:1.19.0'
+  //implementation "org.mockito:mockito-core:2.+" # maven requires  strict syntax
+  implementation "org.mockito:mockito-core:2.28.2"
+  compile 'com.github.stefanbirkner:system-rules:1.19.0'
+  */
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
-  testImplementation "org.mockito:mockito-core:2.+"
+  //testImplementation "org.mockito:mockito-core:2.+"
+  testImplementation "org.mockito:mockito-core:2.28.2"
+
 }
 
 jar {
@@ -76,6 +105,13 @@ task copyJar(type: Copy) {
 shadowJar.finalizedBy copyJar
 
 sourceSets {
+  /* 
+  main {
+    java {
+      srcDirs = ['src/main']
+    }
+  }
+  */  
   integrationTest {
     java {
       srcDirs = [ 'src/test/java/com/appland/appmap/integration' ]
@@ -124,3 +160,142 @@ jacocoTestReport {
     html.enabled true
   }
 }
+
+// extra artifacts used in publishing
+
+/*
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier = 'sources'
+}
+*/
+
+apply plugin: 'java' 
+java {
+    withSourcesJar() 
+    // withJavadocJar()  -- fails with errors, see wowrkaround below
+}
+
+// for some reason this block generates empty Javadoc
+// which we use as a workaround to bypass javadoc errors issue
+javadoc {
+    exclude 'com/appland/**'
+}
+task mockJavadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+
+
+apply plugin: 'maven-publish'
+publishing {
+  publications {
+            
+        appMapAgent(MavenPublication) {
+
+            // requirements: https://central.sonatype.org/pages/requirements.html
+
+            // 1. coordinates (parameterized)   
+   
+                 
+            groupId     publishGroupId
+            artifactId  publishArtifactId + '-' + versionSuffix
+    
+            // version defined globally
+ 
+            // 2. artifacts 
+            // inclusion of javadoc and source jars is Maven-Central requirement
+
+            from components.java
+        
+            artifact shadowJar 
+            artifact mockJavadocJar // empty javadoc generated until errors are fixed
+
+            //// the artifacts below added automatically by `java { with... }` block above
+            // artifact sourcesJar
+            // artifact javadocJar
+
+   
+            // metadata 
+            // TBD: parameterize more values?
+
+
+            pom {
+                name = "$publishGroupId:$publishArtifactId"
+                description = "Inspect and record the execution of Java for use with App Land"
+                url = "https://appland.com"     
+            
+                licenses {
+                  license {
+                    name = "MIT"
+                    url = "https://raw.githubusercontent.com/$currentGitSlug/master/LICENSE.txt"
+                  }
+                }
+                developers {
+                  developer {
+                    // id = "kgilpin"
+                    name = "Kevin Gilpin"
+                    email = "kevin@appland.com"
+                    organization = "AppLand Inc."
+                    url="https://dev.to/kgilpin"
+                  }
+                }
+                scm {
+                    connection = "scm:git:git://github.com/${currentGitSlug}.git"
+                    developerConnection = "scm:git:ssh://github.com:${currentGitSlug}.git"
+                    url = "https://github.com/${currentGitSlug}/tree/master"
+                }
+            }          
+ 
+        }
+  }
+ 
+   repositories {
+
+        def local_url       = "file://${buildDir}/repo"
+        // see https://central.sonatype.org/pages/gradle.html
+        //def default_base        = "https://s01.oss.sonatype.org"
+        def default_base    = "https://oss.sonatype.org"
+        def url_base        = findProperty("mavenRepoURL") ?: default_base
+        def staging_url     = url_base + "/service/local/staging/deploy/maven2/"
+        def snapshots_url   = url_base + "/content/repositories/snapshots/"
+        
+        def is_snapshot     = version.endsWith('SNAPSHOT')
+        def remote_url      = is_snapshot  ? snapshots_url : staging_url 
+        
+        def ossrh_username = findProperty('ossrhUsername') 
+        
+        
+        maven {
+            if (ossrh_username) {
+                url = remote_url 
+                credentials {
+                    username = ossrh_username 
+                    password = getProperty('ossrhPassword') 
+                }
+            } else {
+                url = local_url
+            }
+        }
+
+            
+    }
+   
+}
+
+
+
+if (project.hasProperty("signingKey")) {
+    
+    apply plugin: 'signing' 
+    
+    signing {
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.appMapAgent
+    }
+}
+
+


### PR DESCRIPTION
* Support publication to OSSRH repo (both manual and Travis-managed) for the Agent, 
* Meet Maven Central requirements to Agent artifacts, 
* Fix Travis docker pull issue (anonymous pulls fail regularly due to exceeding Dockerhub's rate limits)

Changes squashed into cumulative commit

More details and release management guide in [CI-README.md](https://github.com/hleb-rubanau/appmap-java/blob/agent-publication-travis-maven/CI-README.md)