### PR TITLE
fix: Don't append System path to class pools

### DIFF
--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -151,7 +151,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
                           Class redefiningClass,
                           ProtectionDomain domain,
                           byte[] bytes) throws IllegalClassFormatException {
-    ClassPool classPool = new ClassPool(true);
+    ClassPool classPool = new ClassPool();
     classPool.appendClassPath(new LoaderClassPath(loader));
 
     try {


### PR DESCRIPTION
See:
https://www.javassist.org/html/javassist/ClassPool.html#%3Cinit%3E(boolean)

In rare cases, appending the System path here caused ClassDefNotFound
exceptions to be raised from within user code.