### PR TITLE
Fix: Dont panic on unknown event ordinal

### DIFF
--- a/src/main/java/com/appland/appmap/output/v1/ParametersSerializer.java
+++ b/src/main/java/com/appland/appmap/output/v1/ParametersSerializer.java
@@ -48,7 +48,7 @@ public class ParametersSerializer implements ObjectSerializer {
       out.write(JSON.toJSONString(valuesField.get(params)));
     } catch (Exception e) {
       Logger.println("failed to serialize parameters");
-      Logger.println(e.getMessage());
+      Logger.println(e);
       out.writeNull();
     }
   }

--- a/src/main/java/com/appland/appmap/record/EventTemplateRegistry.java
+++ b/src/main/java/com/appland/appmap/record/EventTemplateRegistry.java
@@ -94,6 +94,7 @@ public class EventTemplateRegistry {
 
       if (Properties.DebugHooks) {
         Logger.println(msg);
+        Logger.println(e);
       }
 
       throw new UnknownEventException(msg);

--- a/src/main/java/com/appland/appmap/record/EventTemplateRegistry.java
+++ b/src/main/java/com/appland/appmap/record/EventTemplateRegistry.java
@@ -1,8 +1,12 @@
 package com.appland.appmap.record;
 
+import com.appland.appmap.config.Properties;
 import com.appland.appmap.output.v1.CodeObject;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.output.v1.Value;
+import com.appland.appmap.record.UnknownEventException;
+import com.appland.appmap.util.Logger;
+
 import javassist.CtBehavior;
 
 import java.util.ArrayList;
@@ -57,7 +61,7 @@ public class EventTemplateRegistry {
   public Event getTemplate(Integer templateId) {
     try {
       return eventTemplates.get(templateId);
-    } catch (ArrayIndexOutOfBoundsException e) {
+    } catch (IndexOutOfBoundsException e) {
       // fall through
     }
     return null;
@@ -85,8 +89,14 @@ public class EventTemplateRegistry {
           event.addParameter(param);
         }
       }
-    } catch (ArrayIndexOutOfBoundsException e) {
-      throw new UnknownEventException(String.format("unknown template for ordinal %d", templateId));
+    } catch (IndexOutOfBoundsException e) {
+      final String msg = String.format("unknown template for ordinal %d - have we been loaded by a non-system class loader?", templateId);
+
+      if (Properties.DebugHooks) {
+        Logger.println(msg);
+      }
+
+      throw new UnknownEventException(msg);
     }
     
     return event;

--- a/src/main/java/com/appland/appmap/record/EventTemplateRegistry.java
+++ b/src/main/java/com/appland/appmap/record/EventTemplateRegistry.java
@@ -5,7 +5,7 @@ import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.output.v1.Value;
 import javassist.CtBehavior;
 
-import java.util.Vector;
+import java.util.ArrayList;
 
 /**
  * Stores events as templates built from behaviors intended to be hooked. Hooks can then access and
@@ -17,7 +17,7 @@ public class EventTemplateRegistry {
   private static EventTemplateRegistry instance = new EventTemplateRegistry();
   private static final Recorder recorder = Recorder.getInstance();
 
-  private Vector<Event> eventTemplates = new Vector<Event>();
+  private ArrayList<Event> eventTemplates = new ArrayList<Event>();
 
   private EventTemplateRegistry() { }
 
@@ -43,7 +43,7 @@ public class EventTemplateRegistry {
    * @param behavior The behavior used to create the {@link Event} template
    * @returns The behavior ordinal (an index to the {@link Event} template)
    */
-  public Integer register(Event event, CtBehavior behavior) {
+  public synchronized Integer register(Event event, CtBehavior behavior) {
     recorder.register(CodeObject.createTree(behavior));
     eventTemplates.add(event);
     return eventTemplates.size() - 1;

--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -52,7 +52,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
         ctClass.detach();
       } catch (NotFoundException e) {
         Logger.printf("failed to find %s in class pool", classType.getName());
-        Logger.println(e.getMessage());
+        Logger.println(e);
       }
     } 
   }
@@ -103,7 +103,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
         hook.validate();
       } catch (HookValidationException e) {
         Logger.println("failed to validate hook");
-        Logger.println(e.getMessage());
+        Logger.println(e);
         continue;
       }
 

--- a/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
@@ -54,7 +54,7 @@ public class CallbackOnSystem extends BaseSystem {
           runtimeParameters.add(returnValue);
         } catch (NotFoundException e) {
           Logger.println("warning - unknown return type");
-          Logger.println(e.getMessage());
+          Logger.println(e);
         }
       }
     } else if (this.methodEvent == MethodEvent.METHOD_EXCEPTION) {

--- a/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
@@ -42,8 +42,10 @@ class CtClassUtil {
         superClass = superClass.getSuperclass();
       }
     } catch (NotFoundException e) {
-      Logger.println("could not resolve class hierarchy");
-      Logger.println(e);
+      if (Properties.DebugHooks) {
+        Logger.println("could not resolve class hierarchy");
+        Logger.println(e);
+      }
     }
 
     return false;

--- a/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CtClassUtil.java
@@ -1,5 +1,6 @@
 package com.appland.appmap.transform.annotations;
 
+import com.appland.appmap.config.Properties;
 import com.appland.appmap.util.Logger;
 
 import javassist.CtClass;
@@ -42,7 +43,7 @@ class CtClassUtil {
       }
     } catch (NotFoundException e) {
       Logger.println("could not resolve class hierarchy");
-      Logger.println(e.getMessage());
+      Logger.println(e);
     }
 
     return false;

--- a/src/main/java/com/appland/appmap/transform/annotations/Hook.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/Hook.java
@@ -1,5 +1,6 @@
 package com.appland.appmap.transform.annotations;
 
+import com.appland.appmap.config.Properties;
 import com.appland.appmap.output.v1.Parameters;
 import com.appland.appmap.record.EventTemplateRegistry;
 import com.appland.appmap.util.Logger;
@@ -188,14 +189,16 @@ public class Hook {
           ClassPool.getDefault().get("java.lang.Exception"));
       
     } catch (CannotCompileException e) {
-      Logger.println("failed to compile");
-      Logger.println("       method "
-          + targetBehavior.getDeclaringClass().getName()
-          + "."
-          + targetBehavior.getName());
-      Logger.println("  cause: " + e.getCause());
-      Logger.println("  reason: " + e.getReason());
-      Logger.println(e);
+      if (Properties.DebugHooks) {
+        Logger.println("failed to compile");
+        Logger.println("       method "
+            + targetBehavior.getDeclaringClass().getName()
+            + "."
+            + targetBehavior.getName());
+        Logger.println("  cause: " + e.getCause());
+        Logger.println("  reason: " + e.getReason());
+        Logger.println(e);
+      }
     } catch (NotFoundException e) {
       Logger.println("failed to find class\n");
       Logger.println(e);

--- a/src/main/java/com/appland/appmap/transform/annotations/Hook.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/Hook.java
@@ -195,12 +195,10 @@ public class Hook {
           + targetBehavior.getName());
       Logger.println("  cause: " + e.getCause());
       Logger.println("  reason: " + e.getReason());
-      
-
-      Logger.println(e.getMessage());
+      Logger.println(e);
     } catch (NotFoundException e) {
       Logger.println("failed to find class\n");
-      Logger.println(e.getMessage());
+      Logger.println(e);
     }
   }
 
@@ -288,7 +286,7 @@ public class Hook {
         returnType = ((CtMethod) behavior).getReturnType();
       } catch (NotFoundException e) {
         Logger.println("warning - unknown return type");
-        Logger.println(e.getMessage());
+        Logger.println(e);
       }
     }
     return returnType;

--- a/src/main/java/com/appland/appmap/transform/annotations/HookConditionSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookConditionSystem.java
@@ -57,7 +57,7 @@ public class HookConditionSystem extends SourceMethodSystem {
       return (Boolean) this.conditionMethod.invoke(null, behavior);
     } catch (Exception e) {
       Logger.printf("match failed due to %s exception\n", e.getClass().getName());
-      Logger.println(e.getMessage());
+      Logger.println(e);
       return false;
     }
   }

--- a/src/main/java/com/appland/appmap/util/Logger.java
+++ b/src/main/java/com/appland/appmap/util/Logger.java
@@ -8,8 +8,8 @@ import com.appland.appmap.config.Properties;
 public class Logger {
   private static PrintStream log = ensureLog();
   
-  public static void println(Exception e) {
-    Logger.println(e.getMessage());
+  public static void println(Throwable e) {
+    e.printStackTrace(log);
   }
 
   public static void println(String msg) {

--- a/src/test/java/com/appland/appmap/record/EventTemplateRegistryTest.java
+++ b/src/test/java/com/appland/appmap/record/EventTemplateRegistryTest.java
@@ -3,35 +3,57 @@
  */
 package com.appland.appmap.record;
 
+import com.appland.appmap.record.EventTemplateRegistry;
+import com.appland.appmap.record.UnknownEventException;
+import com.appland.appmap.test.util.ClassBuilder;
+
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.CtMethod;
 import javassist.NotFoundException;
+
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 public class EventTemplateRegistryTest {
+  private static final EventTemplateRegistry registry = EventTemplateRegistry.get();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
-  public void testRegister() {
+  public void testRegister() throws Exception {
     ArrayList<CtMethod> behaviorsToRegister = new ArrayList<CtMethod>();
+    ClassPool classPool = ClassPool.getDefault();
+    CtClass classType = classPool.get("com.appland.appmap.ExampleClass");
 
-    try {
-      ClassPool classPool = ClassPool.getDefault();
-      CtClass classType = classPool.get("com.appland.appmap.ExampleClass");
-
-      behaviorsToRegister.add(classType.getDeclaredMethod("methodStaticZeroParam"));
-      behaviorsToRegister.add(classType.getDeclaredMethod("methodStaticSingleParam"));
-      behaviorsToRegister.add(classType.getDeclaredMethod("methodZeroParam"));
-      behaviorsToRegister.add(classType.getDeclaredMethod("methodOneParam"));
-    } catch (NotFoundException e) {
-      fail(e.getMessage());
-    }
+    behaviorsToRegister.add(classType.getDeclaredMethod("methodStaticZeroParam"));
+    behaviorsToRegister.add(classType.getDeclaredMethod("methodStaticSingleParam"));
+    behaviorsToRegister.add(classType.getDeclaredMethod("methodZeroParam"));
+    behaviorsToRegister.add(classType.getDeclaredMethod("methodOneParam"));
 
     for (CtMethod method : behaviorsToRegister) {
-      EventTemplateRegistry.get().register(method);
+      registry.register(method);
     }
+  }
+
+  @Test
+  public void testCloneEventTemplate() throws UnknownEventException, Exception {
+    CtClass myClass = new ClassBuilder("testCloneEventTemplateClass")
+        .beginMethod()
+          .setName("registeredMethod")
+        .endMethod()
+        .ctClass();
+
+    Integer index = registry.register(myClass.getDeclaredMethod("registeredMethod"));
+    assertTrue(registry.cloneEventTemplate(index, "") != null);
+
+    thrown.expect(UnknownEventException.class);
+    registry.cloneEventTemplate(Integer.MAX_VALUE, "");
   }
 }


### PR DESCRIPTION
This change:
- Prevents unexpected exceptions from being raised within the host application
- Logs full stack traces on exception and moves some debug logging behind the "hooks" flag
- Potentially (untested) speeds up method hooks