### PR TITLE
Feature: Add a System property to automatically start recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ test {
 - `appmap.debug` Enable debug logging. Default: `null` (disabled)
 - `appmap.event.valueSize` Specifies the length of a value string before
   truncation occurs. If set to `0`, truncation is disabled. Default: `1024`
+- `appmap.recording.auto` Automatically begin recording at boot time. Default:
+  `false`
+- `appmap.recording.file` The file name of the automatic recording to be
+  emitted. Note that the file name will still be prefixed by
+  `appmap.output.directory`. Default: `$TIMESTAMP.appmap.json`
+- `appmap.recording.name` Populates the `metadata.name` field of the AppMap.
+  Default: `$TIMESTAMP`
 
 ## Operation
 

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -11,6 +11,13 @@ public class Properties {
   public static final String DebugFile = resolveProperty("appmap.debug.file", (String)null);
   public static final Boolean DebugHttp = System.getProperty("appmap.debug.http") != null;
 
+  public static final Boolean RecordingAuto = resolveProperty(
+      "appmap.recording.auto", Boolean::valueOf, false);
+  public static final String RecordingName = resolveProperty(
+      "appmap.recording.name", (String)null);
+  public static final String RecordingFile = resolveProperty(
+      "appmap.recording.file", (String)null);
+
   public static final String DefaultOutputDirectory = "./tmp/appmap";
   public static final String OutputDirectory = resolveProperty(
       "appmap.output.directory", DefaultOutputDirectory);

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -200,7 +200,7 @@ public class ToggleRecord {
         decapitalize(metadata.feature));
       metadata.recordedClassName = event.definedClass;
       metadata.recordedMethodName = event.methodId;
-      recorder.start(fileName, metadata);
+      recorder.start(fileName + ".appmap.json", metadata);
     } catch (ActiveSessionException e) {
       Logger.printf("%s\n", e.getMessage());
     }

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -231,7 +231,7 @@ public class Recorder {
     final Metadata metadata = new Metadata();
     metadata.scenarioName = name;
 
-    this.start(fileName, metadata);
+    this.start(fileName + ".appmap.json", metadata);
     fn.run();
     this.stop();
   }

--- a/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
+++ b/src/main/java/com/appland/appmap/record/RecordingSessionFileStream.java
@@ -27,8 +27,8 @@ public class RecordingSessionFileStream extends RecordingSessionGeneric {
    */
   public RecordingSessionFileStream(String fileName, Metadata metadata) {
     this.metadata = metadata;
-    if (fileName != null) {
-      this.fileName = String.format("%s.appmap.json", fileName);
+    if (fileName != null && !fileName.trim().isEmpty()) {
+      this.fileName = fileName;
     }
   }
 


### PR DESCRIPTION
Specifying `-Dappmap.recording.auto=true` prompts the agent to automatically begin recording upon boot. An AppMap will be emitted upon exit.