### PR TITLE
fix: Don't call into user toString

### DIFF
--- a/src/main/java/com/appland/appmap/output/v1/Value.java
+++ b/src/main/java/com/appland/appmap/output/v1/Value.java
@@ -116,19 +116,11 @@ public class Value {
    */
   public Value freeze() {
     if (this.value != null) {
-      try {
+      final String className = this.value.getClass().getName();
+      if (className.startsWith("java.")) {
         this.value = this.value.toString();
-
-        if (Properties.MaxValueSize > 0 && this.value != null) {
-          this.value = StringUtils.abbreviate((String) this.value, "...", Properties.MaxValueSize);
-        }
-      } catch (Throwable e) {
-        Logger.println("failed to resolve value of " + this.classType);
-        Logger.println(e.getMessage());
-        // it's possible our value object has been partially cleaned up and
-        // calls toString on a null object or the operation is otherwise
-        // unsupported
-        this.value = "< invalid >";
+      } else {
+        this.value = className + '@' + Integer.toHexString(hashCode());
       }
     }
     return this;

--- a/src/test/java/com/appland/appmap/ExampleClass.java
+++ b/src/test/java/com/appland/appmap/ExampleClass.java
@@ -33,4 +33,8 @@ public class ExampleClass {
     String local = "variables";
     buildString(this.someState, x, local);
   }
+
+  public String toString() {
+    throw new RuntimeException("this method should never be called");
+  }
 }

--- a/src/test/java/com/appland/appmap/output/v1/ValueTest.java
+++ b/src/test/java/com/appland/appmap/output/v1/ValueTest.java
@@ -1,0 +1,24 @@
+package com.appland.appmap.output.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.appland.appmap.ExampleClass;
+
+import java.util.Date;
+
+public class ValueTest {
+
+  @Test
+  public void freezeCallsCorrectMethod() {
+    final ExampleClass myExampleClass = new ExampleClass();
+    Value v = new Value(myExampleClass).freeze();
+    assertTrue(((String) v.value).matches("^[\\.|\\w]+@[\\da-fA-F]+$"));
+
+    Date date = new Date();
+    v = new Value(date).freeze();
+    assertEquals((String) v.value, date.toString());
+  }
+}


### PR DESCRIPTION
This implementation is naive, but much better than the previous version. Instead of calling `toString` on user classes, return the class name and object ID. Otherwise, if the class is part of the 'java.*' package space, allow `toString` to occur. This should dramatically reduce the amount of side effects we incur at runtime.