### PR TITLE
build(gradle): use GradleNexusPublishing plugin

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -18,7 +18,9 @@ plugins:
         - CHANGELOG.md
         - build.gradle
   - - '@semantic-release/exec'
-    - publishCmd: ./gradlew publish
+    #- publishCmd: ./gradlew publish
+    #- publishCmd: ./gradlew publishToSonatype closeSonatypeStagingRepository
+    - publishCmd: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
   - - '@semantic-release/github'
     - assets:
         - build/libs/appmap-*.jar*

--- a/CI-README.md
+++ b/CI-README.md
@@ -62,44 +62,30 @@ via variable `ORG_GRADLE_PROJECT_publishArtifactId`
 
 # Publishing 
 
-## Manual 
+`semantic-release` invoked by Travis on master branch, 
+triggers publishing task as a hook defined in `.releaserc.yml`
 
-`./gradlew publish`
 
-## Travis 
+Since April 2021 we're using Gradle Nexus Publish plugin, 
+old `./gradlew publish` command is deprecated 
+and likely won't work in "local filesystem" mode any more 
+(not tested and not needed).
 
-Maven publication is triggered by semantic-versioned tags in the form `x.y.z`, 
-`x.y.z-whatever` (releases) or `x.y.z-SNAPSHOT` (snapshots)
+Nexus Publishing plugin takes care not only of uploading artifacts 
+(like previously used `maven-publish` plugin does)
+but also automates 
+[the procedures of "closing" and "releasing" repository in OSSRH](https://central.sonatype.org/pages/releasing-the-deployment.html) 
 
-# Releases
+## Manual invocation of publication task:
 
-Follow the steps in 
-[Official guide](https://central.sonatype.org/pages/releasing-the-deployment.html) 
-to manually close-validate-release the repository after successful publication.
+```./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository```
+(triggered by semantic-release, most complete flow)
 
-*After first release in the namespace happens, do not forget to comment on the 
-OSSRH ticket which was used to claim the namespace.*
+or 
+
+```./gradlew publishToSonatype closeReleaseSonatypeStagingRepository```
+(more conservative, skips the step of pushing to Maven Central)
 
 # Backlog
 
-## Done
-
-
-* Generate Source Jar
-* Generate JavaDoc Jar
-* Publish to local repo
-* Sign artifacts
-* Plug together signing and publishing
-* Fill POM metadata according to Maven requirements
-* Parameterizable coordinates (version, group, artifact)
-* Support Java8
-* Release into real (remote, sonatype) repo
-* BUG: POM contains prohibited syntax for mockito dependency
-* Automate via Travis
-* Regresion in Java8 test
-
-
-## TODO:
-
-* Support release cycle for appmap-java-maven-plugin
 * BUG? Javadoc is intentionally empty due to errors in javadoc generation.

--- a/CI-README.md
+++ b/CI-README.md
@@ -63,15 +63,21 @@ It is recommended to use separate CI robot account for security purposes, as cre
 # CI Configuration
 
 ## Travis 
-Following environment variables need to be configured on a repository level:
-1. `DOCKERHUB_USERNAME` _(visible)_ – any Docker Hub account, preferably CI bot’s.
+Following environment variables should be configured on a repository level:
+1. `DOCKERHUB_USERNAME` _(visible)_ – any Docker Hub account, preferably CI bot’s. Used with password to prevent Docker pulls throttling.
 2. `DOCKERHUB_PASSWORD` _(secret)_
 3. `GH_TOKEN` _(secret)_ -- Github token to be used for pushes done by Semantic Release
 4. `ORG_GRADLE_PROJECT_ossrhUsername` _(visible)_ – Sonatype username for CI bot
 5. `ORG_GRADLE_PROJECT_ossrhPassword` _(secret)_
 6. `ORG_GRADLE_PROJECT_signingKey` _(secret)_ – the exact contents of CI bot’s GPG key in a form suitable for Travis environment ( content of `/tmp/travis_compatible_env_value.txt`, generated above)
 7. `ORG_GRADLE_PROJECT_signingPassword` _(secret)_ -- passphrase for bot's GPG key
-8. `ORG_GRADLE_PROJECT_publishGroupId` _(optional, visible)_ – if releasing to the Maven namespace different from default `com.appland` 
+
+There is also a number of optional, non-secret settings, mostly used for unofficial builds
+
+1. `ORG_GRADLE_PROJECT_publishGroupId`: Maven namespace (default: `com.appland`)
+2. `ORG_GRADLE_PROJECT_publicationArtifactId`: Maven package name (default: `appmap-agent`)
+3. `ORG_GRADLE_PROJECT_mavenRepo`: used to alter OSSRH url if non-default endpoint is used (default: `https://s01.oss.sonatype.org`, legacy: `https://oss.sonatype.org`)
+4. `ORG_GRADLE_PROJECT_artifactDescription`: used to alter the package description for non-official builds, default is defined in [build.gradle](./build.gradle)
 
 ## Developer environment  
 

--- a/CI-README.md
+++ b/CI-README.md
@@ -1,12 +1,57 @@
-﻿# Prerequisites
+﻿# Overview
+
+The ultimate goal of release process is publishing artifacts into [Maven Central repo](https://search.maven.org/search?q=com.appland%20appmap-agent)
+
+Maven Central does not support direct uploads, instead it syncs from a number of partner repositories, one of which is [Sonatype OSSRH](https://ossindex.sonatype.org/component/pkg:maven/com.appland/appmap-agent)
+
+## Release process from Maven perspective:
+
+* **Build**:      Jar artifacts are built (in build environment or on dev machine)
+* **Publishing**: Artifacts are uploaded to OSSRH, forming a (temporary) _"staging repository"_ -- a set of artifacts and metatata files with unique name/version.
+* **Closing**:    Next step, explicitly taken by submitter (via Sonatype UI or API), which freezes _"staging repository"_ and triggers automated integrity checks on it
+* **Releasing**:  Next step, explcitly taken by submitter (via Sonatype UI or API), which initiates **syncing of published and validated artifacts from OSSRH to Maven Central**. 
+* **Dropping**:   After artifacts are "released" to Maven Central, _"staging repository"_ lifecycle is over and it should be deleted from OSSRH.
+
+After releasing, package becomes available via [Maven Central search](https://search.maven.org) within few hours.
+
+*See also: official Sonatype docs on [publication](https://central.sonatype.org/publish/publish-guide/) and [releasing](https://central.sonatype.org/publish/release/)*
+
+
+## Release process from Appland perspective
+
+* **[Travis](https://app.travis-ci.com/github/applandinc/appmap-java) build is triggered by Github push**:
+    * Travis configuration parameters are described below, in "Configuration" section
+    * Most params are exposed to underlying scripts as environment variables 
+* **Travis build execution steps** (settings file: [travis.yml](./travis.yml)):
+    * `script`: a number of tests is executed using [Gradle](https://gradle.org/). Settings file: [build.gradle](./build.gradle) 
+    * `deploy`: further execution is passed to [Semantic Release](https://github.com/semantic-release/semantic-release) utility
+* **Semantic Release execution steps** (settings file: [.releaserc.yml](./.releaserc.yml)):
+    * `commit-analyzer, release-notes-generator, changelog`: new version number is figured out [from commits history](https://github.com/semantic-release/semantic-release#commit-message-format), changelog is updated
+    * `release-replace-plugin`: file [build.gradle](./build.gradle) is patched with new version number
+    * `git`: generated changes are stored as a new Git commit
+    * `exec`: **Gradle command is run to build jar artifacts and publish them to OSSRH/Maven. See details below.**
+    * `github`: changes are pushed to Github as a new Github release
+* **Gradle build specifics** (settings file: [build.gradle](./build.gradle)):
+    * Gradle targets are configured in [build.gradle](./build.gradle) and/or are provided by Gradle plugins included with directives `import`/`plugins`/`apply plugin`
+    * Gradle command is invoked with the top-level target as parameter (e.g. `publishToSonatype closeAndReleaseSonatypeStagingRepository`)
+    * For the provided target, Gradle evaluates dependency graph (consisting of other targets), executes it in reverse order
+* **Gradle build execution steps** (from the bottom to the top of dependency graph):
+    * *parameterization*: build parameters such as maven package names, signing keys are evaluated (some from environment vars)
+    * `shadowJar`: main jar file is built
+    * `sourcesJar`, `mockJavadocJar`: additional jar files, [required by Maven standards](https://central.sonatype.org/publish/requirements/)
+    * *signing*: artifacts are signed (*signing key body* is exposed to script via env variable)  
+    * *publishing, closing, releasing, deletion*: artifacts are published to OSS sonatype (see above), then a chain of `close`-`release`-`delete` actions is processed
+
+
+# CI setup: Prerequisites
 
 
 1. Every release master (person allowed to manage releases), should do following:
-    1.1. Generate GPG pair for signing releases (please use password protection!)
+    1. Generate GPG pair for signing releases (please use password protection!)
         See [Guide 1](https://www.gnupg.org/gph/en/manual/c14.html)  
         also [Guide 2](https://www.redhat.com/sysadmin/creating-gpg-keypairs) 
-    1.2 Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`
-    1.3. [Register sonatype account](https://issues.sonatype.org/secure/Signup!default.jspa)  
+    2. Publish key on public servers via `gpg2 --keyserver hkp://pool.sks-keyservers.net --send-keys <KEYID>`
+    3. [Register sonatype account](https://issues.sonatype.org/secure/Signup!default.jspa)  
 2. The same operations (sonatype account and published GPG identity) should be done for CI bot (please create password-protected key, as suggested by default)
 3. [Create a New Project ticket, requesting new project/namespace to be created.](https://issues.sonatype.org/secure/CreateIssue.jspa?issuetype=21&pid=10134)
 Mention all release masters and CI bot in a list of collaborators.
@@ -15,16 +60,18 @@ Mention all release masters and CI bot in a list of collaborators.
 5. At least one account on https://hub.docker.com is needed, which credentials will be used to avoid hitting limits for anonymous docker pulls, often exceeded by Travis servers.
 It is recommended to use separate CI robot account for security purposes, as credentials would be stored (encrypted) on Travis side.
  
-# Configuration
+# CI Configuration
+
 ## Travis 
 Following environment variables need to be configured on a repository level:
 1. `DOCKERHUB_USERNAME` _(visible)_ – any Docker Hub account, preferably CI bot’s.
 2. `DOCKERHUB_PASSWORD` _(secret)_
-3. `ORG_GRADLE_PROJECT_ossrhUsername` _(visible)_ – Sonatype username for CI bot
-4. `ORG_GRADLE_PROJECT_ossrhPassword` _(secret)_
-5. `ORG_GRADLE_PROJECT_signingKey` _(secret)_ – the exact contents of CI bot’s GPG key in a form suitable for Travis environment ( content of `/tmp/travis_compatible_env_value.txt`, generated above)
-6. `ORG_GRADLE_PROJECT_signingPassword` _(secret)_ -- passphrase for bot's GPG key
-7. `ORG_GRADLE_PROJECT_publishGroupId` _(optional, visible)_ – if releasing to the Maven namespace different from default `com.appland` 
+3. `GH_TOKEN` _(secret)_ -- Github token to be used for pushes done by Semantic Release
+4. `ORG_GRADLE_PROJECT_ossrhUsername` _(visible)_ – Sonatype username for CI bot
+5. `ORG_GRADLE_PROJECT_ossrhPassword` _(secret)_
+6. `ORG_GRADLE_PROJECT_signingKey` _(secret)_ – the exact contents of CI bot’s GPG key in a form suitable for Travis environment ( content of `/tmp/travis_compatible_env_value.txt`, generated above)
+7. `ORG_GRADLE_PROJECT_signingPassword` _(secret)_ -- passphrase for bot's GPG key
+8. `ORG_GRADLE_PROJECT_publishGroupId` _(optional, visible)_ – if releasing to the Maven namespace different from default `com.appland` 
 
 ## Developer environment  
 

--- a/CI-README.md
+++ b/CI-README.md
@@ -33,14 +33,15 @@ After releasing, package becomes available via [Maven Central search](https://se
     * `github`: changes are pushed to Github as a new Github release
 * **Gradle build specifics** (settings file: [build.gradle](./build.gradle)):
     * Gradle targets are configured in [build.gradle](./build.gradle) and/or are provided by Gradle plugins included with directives `import`/`plugins`/`apply plugin`
-    * Gradle command is invoked with the top-level target as parameter (e.g. `publishToSonatype closeAndReleaseSonatypeStagingRepository`)
+    * Gradle command is invoked with the top-level targets as parameters (e.g. `publishToSonatype closeAndReleaseSonatypeStagingRepository`)
     * For the provided target, Gradle evaluates dependency graph (consisting of other targets), executes it in reverse order
 * **Gradle build execution steps** (from the bottom to the top of dependency graph):
     * *parameterization*: build parameters such as maven package names, signing keys are evaluated (some from environment vars)
     * `shadowJar`: main jar file is built
     * `sourcesJar`, `mockJavadocJar`: additional jar files, [required by Maven standards](https://central.sonatype.org/publish/requirements/)
+    * *publishing*: metadata files (with package name, version, description etc.) are generated
     * *signing*: artifacts are signed (*signing key body* is exposed to script via env variable)  
-    * *publishing, closing, releasing, deletion*: artifacts are published to OSS sonatype (see above), then a chain of `close`-`release`-`delete` actions is processed
+    * `publishToSonatype closeAndReleaseSonatypeStagingRepository` (targets provided by Gradle Nexus Publishing plugin): artifacts are published to OSSRH (see above), then a chain of `close`-`release`-`drop` actions is processed. 
 
 
 # CI setup: Prerequisites

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
   id 'war'
   id 'jacoco'
   id 'signing'
+  id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
 }
 
 repositories {
@@ -29,7 +30,6 @@ def defaultVersion          = '1.0.4'
 def versionLikeRegexp       = /^\d+\.\d+.*/
 def travisVersionValid      = travisVersion && (travisVersion ==~ versionLikeRegexp)
 
-version = parameterizedVersion ?: ( travisVersionValid ? travisVersion : defaultVersion )
 
 def defaultGitSlug="applandinc/appmap-java"
 def currentGitSlug=System.getenv("TRAVIS_REPO_SLUG") ?: defaultGitSlug
@@ -39,6 +39,11 @@ def defaultArtifactId   = 'appmap-agent'
 def publishGroupId      = findProperty('publishGroupId') ?: defaultGroupId
 def publishArtifactId   = findProperty('publishArtifactId') ?: defaultArtifactId
 
+
+// these two are required by Gradle-Nexus-Publishing
+version = parameterizedVersion ?: ( travisVersionValid ? travisVersion : defaultVersion )
+group = publishGroupId
+            
 dependencies {
   implementation 'org.yaml:snakeyaml:1.25'
   implementation 'com.alibaba:fastjson:1.2.61'
@@ -212,37 +217,32 @@ publishing {
         }
   }
 
-   repositories {
 
-        def local_url       = "file://${buildDir}/repo"
-        // see https://central.sonatype.org/pages/gradle.html
-        def default_base        = "https://s01.oss.sonatype.org"
-        //def default_base    = "https://oss.sonatype.org"
-        def url_base        = findProperty("mavenRepoURL") ?: default_base
-        def staging_url     = url_base + "/service/local/staging/deploy/maven2/"
-        def snapshots_url   = url_base + "/content/repositories/snapshots/"
-
-        def is_snapshot     = version.endsWith('SNAPSHOT')
-        def remote_url      = is_snapshot ? snapshots_url : staging_url
-
-        def ossrh_username  = findProperty('ossrhUsername')
-
-
-        maven {
-            if (ossrh_username) {
-                url = remote_url
-                credentials {
-                    username = ossrh_username
-                    password = getProperty('ossrhPassword')
-                }
-            } else {
-                url = local_url
-            }
-        }
-    }
 }
 
+nexusPublishing {
+    repositories {
+        sonatype { 
 
+            // this is evaluated even when task itself is not invoked
+            // so we use fault-tolerant `findProperty` instead of strict `getProperty`
+            // solely in order to allow building artifacts 
+            // without runtime configuration (e.g. in context of Docker build)
+
+            // see https://central.sonatype.org/pages/gradle.html
+            def default_base        = "https://s01.oss.sonatype.org"
+            //def default_base    = "https://oss.sonatype.org"
+            def url_base        = findProperty("mavenRepoURL") ?: default_base 
+
+            nexusUrl                = uri(  url_base + "/service/local/")
+            //nexusUrl                = uri(  url_base + "/service/local/staging/deploy/maven2/")   
+            snapshotRepositoryUrl   = uri(  url_base + "/content/repositories/snapshots" )        
+            username                = project.findProperty('ossrhUsername')    
+            password                = project.findProperty('ossrhPassword')    
+        }
+    }
+
+}
 
 if (project.hasProperty("signingKey")) {
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ def defaultArtifactId   = 'appmap-agent'
 def publishGroupId      = findProperty('publishGroupId') ?: defaultGroupId
 def publishArtifactId   = findProperty('publishArtifactId') ?: defaultArtifactId
 
+def defaultDescription = "Inspect and record the execution of Java for use with App Land"
+def parameterizedDescription = findProperty('appMapAgentDescription') ?: defaultDescription
+
 
 // these two are required by Gradle-Nexus-Publishing
 version = parameterizedVersion ?: ( travisVersionValid ? travisVersion : defaultVersion )
@@ -190,7 +193,7 @@ publishing {
 
             pom {
                 name = "$publishGroupId:$publishArtifactId"
-                description = "Inspect and record the execution of Java for use with App Land"
+                description = parameterizedDescription
                 url = "https://appland.com"
 
                 licenses {


### PR DESCRIPTION
Gradle plugin `Nexus Publishing` ( instead of previously used `maven-publish` ) is used to automate artifacts publication to  OSSRH / Maven Central .

Now, not only artifact uploading but also subsequent publication steps ("closing", "releasing", "dropping") are controlled by Gradle. (See `CI-README.md` for more info about these concepts and for the build process overview).
 
**Important**: the command used for publication has changed from `./gradlew publish` to `./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository`, 

see `.releaserc.yml` and `CI-README.md` for the details.