### PR TITLE
feat: Package recording options

### DIFF
--- a/src/main/java/com/appland/appmap/Agent.java
+++ b/src/main/java/com/appland/appmap/Agent.java
@@ -31,12 +31,7 @@ public class Agent {
    * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/lang/instrument/package-summary.html">Package java.lang.instrument</a>
    */
   public static void premain(String agentArgs, Instrumentation inst) {
-    final File dir = new File(Properties.OutputDirectory);
-    if (!dir.exists()) {
-      if (!dir.mkdirs()) {
-        Logger.println("failed to create directories: " + Properties.OutputDirectory);
-      }
-    }
+    final File dir = Properties.getOutputDirectory();
 
     Logger.printf("agent loaded using config %s\n", Properties.ConfigFile);
 
@@ -72,7 +67,7 @@ public class Agent {
         }
 
         Recording recording = recorder.stop();
-        recording.moveTo(fileName);
+        recording.moveTo(String.join(File.pathSeparator, new String[]{ dir.getPath(), fileName }));
       }));
     }
   }

--- a/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -88,4 +88,14 @@ public class AppMapConfig {
 
     return false;
   }
+
+  public boolean isShallow(String canonicalName) {
+    for (AppMapPackage pkg : this.packages) {
+      if (pkg.includes(canonicalName)) {
+        return pkg.shallow;
+      }
+    }
+
+    return false;
+  }
 }

--- a/src/main/java/com/appland/appmap/config/AppMapPackage.java
+++ b/src/main/java/com/appland/appmap/config/AppMapPackage.java
@@ -3,6 +3,7 @@ package com.appland.appmap.config;
 public class AppMapPackage {
   public String path;
   public String[] exclude = new String[] {};
+  public boolean shallow = false;
 
   /**
    * Check if a class/method is included in the configuration.

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -2,6 +2,7 @@ package com.appland.appmap.config;
 
 import com.appland.appmap.util.Logger;
 
+import java.io.File;
 import java.util.function.Function;
 
 public class Properties {
@@ -46,6 +47,16 @@ public class Properties {
       Logger.println(e);
     }
     return value;
+  }
+
+  public static File getOutputDirectory() {
+    final File dir = new File(OutputDirectory);
+    if (!dir.exists()) {
+      if (!dir.mkdirs()) {
+        Logger.println("failed to create directories: " + Properties.OutputDirectory);
+      }
+    }
+    return dir;
   }
 
   private static <T> T resolveProperty(String propName,

--- a/src/main/java/com/appland/appmap/output/v1/Event.java
+++ b/src/main/java/com/appland/appmap/output/v1/Event.java
@@ -61,6 +61,7 @@ public class Event {
   public SqlQuery sqlQuery;
 
   private boolean frozen = false;
+  private boolean ignored = false;
 
   private synchronized Integer issueId() {
     return ++globalEventId;
@@ -132,6 +133,13 @@ public class Event {
   public boolean frozen() {
     return frozen;
   }
+
+  public void ignore() { ignored = true; }
+
+  /**
+   * @return true if the event should not be emitted to the AppMap file.
+   */
+  public boolean ignored() { return ignored; }
 
   /**
    * Set the "event" string.

--- a/src/main/java/com/appland/appmap/output/v1/Event.java
+++ b/src/main/java/com/appland/appmap/output/v1/Event.java
@@ -5,6 +5,7 @@ import javassist.CtBehavior;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Represents a snapshot of a method invocation, return, exception or some other kind of runtime
@@ -62,6 +63,7 @@ public class Event {
 
   private boolean frozen = false;
   private boolean ignored = false;
+  private String packageName;
 
   private synchronized Integer issueId() {
     return ++globalEventId;
@@ -141,6 +143,10 @@ public class Event {
    */
   public boolean ignored() { return ignored; }
 
+  public boolean hasPackageName() { return packageName != null; }
+
+  public String packageName() { return packageName; }
+
   /**
    * Set the "event" string.
    * @param event "call", "return", etc.
@@ -171,6 +177,9 @@ public class Event {
    */
   public Event setDefinedClass(String definedClass) {
     this.definedClass = definedClass;
+    String[] tokens = definedClass.split("\\.");
+    this.packageName = String.join(".", Arrays.copyOf(tokens, tokens.length - 1));
+
     return this;
   }
 

--- a/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
+++ b/src/main/java/com/appland/appmap/process/hooks/ToggleRecord.java
@@ -13,6 +13,7 @@ import com.appland.appmap.reflect.HttpServletResponse;
 import com.appland.appmap.transform.annotations.*;
 import com.appland.appmap.util.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 
@@ -249,7 +250,7 @@ public class ToggleRecord {
       recorder.getMetadata().exception = exception;
     }
     Recording recording = recorder.stop();
-    recording.moveTo(filePath);
+    recording.moveTo(String.join(File.separator, new String[]{ Properties.getOutputDirectory().getPath(), filePath }));
   }
 
   @ArgumentArray

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -1,10 +1,12 @@
 package com.appland.appmap.record;
 
 import com.appland.appmap.config.AppMapConfig;
+import com.appland.appmap.config.Properties;
 import com.appland.appmap.output.v1.CodeObject;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.util.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -258,7 +260,7 @@ public class Recorder {
     this.start(metadata);
     fn.run();
     Recording recording = this.stop();
-    recording.moveTo(fileName + ".appmap.json");
+    recording.moveTo(String.join(File.separator, new String[]{ Properties.getOutputDirectory().getPath(), fileName + ".appmap.json" }));
   }
 
   ThreadState threadState() {

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -1,10 +1,12 @@
 package com.appland.appmap.record;
 
+import com.appland.appmap.config.AppMapConfig;
 import com.appland.appmap.output.v1.CodeObject;
 import com.appland.appmap.output.v1.Event;
 import com.appland.appmap.util.Logger;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
@@ -83,6 +85,12 @@ public class Recorder {
 
       activeSession = session;
     }
+
+    synchronized void addEvent(Event event) {
+      if (activeSession != null) {
+        activeSession.add(event);
+      }
+    }
   }
 
   /**
@@ -104,9 +112,8 @@ public class Recorder {
    * @throws ActiveSessionException If a session is already in progress
    */
   public void start(Metadata metadata) throws ActiveSessionException {
-    RecordingSession session = new RecordingSession();
+    RecordingSession session = new RecordingSession(metadata);
     activeSession.set(session);
-    session.start(metadata);
   }
 
   public boolean hasActiveSession() {
@@ -154,6 +161,13 @@ public class Recorder {
     ts.isProcessing = true;
     try {
       if ( event.event.equals("call") ) {
+        if ( !ts.callStack.empty() && event.definedClass != null && AppMapConfig.get().isShallow(event.definedClass) ) {
+          Event parent = ts.callStack.peek();
+          if ( parent.definedClass != null && packageName(event.definedClass).equals(packageName(parent.definedClass)) ) {
+            event.ignore();
+          }
+        }
+
         ts.callStack.push(event);
       } else if ( event.event.equals("return") ) {
         if ( ts.callStack.isEmpty() ) {
@@ -175,6 +189,9 @@ public class Recorder {
         event.definedClass = null;
         event.methodId = null;
         event.isStatic = null;
+        if ( caller.ignored() ) {
+          event.ignore();
+        }
       } else {
         throw new IllegalArgumentException("Event should be 'call' or 'return', got " + event.event);
       }
@@ -183,14 +200,19 @@ public class Recorder {
       ts.lastEvent = event;
 
       // The previous event is given until now to get all its properties.
-      if ( previousEvent != null ) {
+      if ( previousEvent != null && !previousEvent.ignored() ) {
         // This is the line that can generate re-entrant events, apparently.
         previousEvent.freeze();
-        activeSession.get().add(previousEvent);
+        activeSession.addEvent(previousEvent);
       }
     } finally {
       ts.isProcessing = false;
     }
+  }
+
+  private String packageName(String className) {
+    String[] tokens = className.split("\\.");
+    return String.join(".", Arrays.copyOf(tokens, tokens.length - 1));
   }
 
   /**
@@ -261,7 +283,7 @@ public class Recorder {
         ts.lastEvent = null;
 
         event.freeze();
-        activeSession.get().add(event);
+        activeSession.addEvent(event);
       } finally {
         ts.isProcessing = false;
       }

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -163,9 +163,9 @@ public class Recorder {
     ts.isProcessing = true;
     try {
       if ( event.event.equals("call") ) {
-        if ( !ts.callStack.empty() && event.definedClass != null && AppMapConfig.get().isShallow(event.definedClass) ) {
+        if ( !ts.callStack.empty() && event.hasPackageName() && AppMapConfig.get().isShallow(event.definedClass) ) {
           Event parent = ts.callStack.peek();
-          if ( parent.definedClass != null && packageName(event.definedClass).equals(packageName(parent.definedClass)) ) {
+          if ( parent.hasPackageName() && event.packageName().equals(parent.packageName()) ) {
             event.ignore();
           }
         }
@@ -210,11 +210,6 @@ public class Recorder {
     } finally {
       ts.isProcessing = false;
     }
-  }
-
-  private String packageName(String className) {
-    String[] tokens = className.split("\\.");
-    return String.join(".", Arrays.copyOf(tokens, tokens.length - 1));
   }
 
   /**

--- a/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/CallbackOnSystem.java
@@ -11,7 +11,7 @@ import javassist.NotFoundException;
 public class CallbackOnSystem extends BaseSystem {
   private static final MethodEvent DEFAULT_VALUE = MethodEvent.METHOD_INVOCATION;
 
-  private MethodEvent methodEvent;
+  private final MethodEvent methodEvent;
 
   private CallbackOnSystem(CtBehavior hookBehavior, MethodEvent methodEvent) {
     super(hookBehavior);
@@ -38,7 +38,7 @@ public class CallbackOnSystem extends BaseSystem {
   public void mutateRuntimeParameters(HookBinding binding, Parameters runtimeParameters) {
     if (this.methodEvent == MethodEvent.METHOD_RETURN) {
       final CtBehavior targetBehavior = binding.getTargetBehavior();
-      if (targetBehavior instanceof CtMethod) {
+      if (targetBehavior.getMethodInfo().isMethod()) {
         try {
           CtMethod method = (CtMethod) targetBehavior;
           CtClass returnType = method.getReturnType();

--- a/test/agent-cli/.gitignore
+++ b/test/agent-cli/.gitignore
@@ -1,0 +1,2 @@
+spring-petclinic
+


### PR DESCRIPTION
* feat: Implement `shallow` mode …

Packages can be marked `shallow`.
In shallow recording mode, subsequent calls to the same package are ignored, until the call stack leaves the package.
This helps to make the trace diagram more compact.

* feat: Ignore common methods …

Ignore getters, setters, and certain common methods on `java.lang.Object`.

* fix: Respect the output directory

