### PR TITLE
FEAT: Shallow recording of nested packages

### DIFF
--- a/src/main/java/com/appland/appmap/config/PackageConfig.java
+++ b/src/main/java/com/appland/appmap/config/PackageConfig.java
@@ -1,0 +1,23 @@
+package com.appland.appmap.config;
+
+/**
+ * Data structure for holding configuration of a package
+ */
+public class PackageConfig {
+
+    public final String packageName;
+    public final String includedPackageName;
+    public final boolean shallow;
+
+    /**
+     * Return configuration of a package
+     * @param packageName name of the package
+     * @param includedPackageName name of the nearest included parent package found in appmap.yml
+     * @param shallow shallow config value of the package, taken from the nearest parent package found in appmap.yml
+     */
+    public PackageConfig(String packageName, String includedPackageName, boolean shallow) {
+        this.packageName = packageName;
+        this.includedPackageName = includedPackageName;
+        this.shallow = shallow;
+    }
+}

--- a/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
+++ b/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
@@ -10,6 +10,7 @@ import java.io.PrintStream;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class AppMapConfigTest {
 
@@ -35,6 +36,53 @@ public class AppMapConfigTest {
         AppMapConfig.load(new File("agent_conf.yml"));
         assertNotNull(errContent.toString());
         assertTrue(errContent.toString().contains("file not found"));
+    }
+
+    /**
+     * Test of nested shallow package configuration
+     */
+    @Test
+    public void testNestedShallowConfig() {
+        AppMapConfig cfg = AppMapConfig.load(new File("build/resources/test/appmap_nested_shallow_test.yml"));
+        PackageConfig pkgCfg;
+
+        pkgCfg = cfg.getPackageConfig("a");
+        assertNotNull(pkgCfg);
+        assertEquals(pkgCfg.includedPackageName, "a");
+        assertTrue(!pkgCfg.shallow);
+
+        pkgCfg = cfg.getPackageConfig("b");
+        assertNotNull(pkgCfg);
+        assertEquals(pkgCfg.includedPackageName, "b");
+        assertTrue(pkgCfg.shallow);
+
+        pkgCfg = cfg.getPackageConfig("b.d");
+        assertNotNull(pkgCfg);
+        assertEquals(pkgCfg.includedPackageName, "b");
+        assertTrue(pkgCfg.shallow);
+
+        pkgCfg = cfg.getPackageConfig("b.b");
+        assertNotNull(pkgCfg);
+        assertEquals(pkgCfg.includedPackageName, "b.b");
+        assertTrue(pkgCfg.shallow);
+
+        pkgCfg = cfg.getPackageConfig("b.c.a");
+        assertNotNull(pkgCfg);
+        assertEquals(pkgCfg.includedPackageName, "b.c");
+        assertTrue(!pkgCfg.shallow);
+
+        pkgCfg = cfg.getPackageConfig("b.c.b");
+        assertNotNull(pkgCfg);
+        assertEquals(pkgCfg.includedPackageName, "b.c.b");
+        assertTrue(pkgCfg.shallow);
+
+        //package x is not included in appmap.yml
+        pkgCfg = cfg.getPackageConfig("x");
+        assertTrue(pkgCfg == null);
+
+        //Memoization test. We want the same object reference returned.
+        assertTrue(cfg.getPackageConfig("a") == cfg.getPackageConfig("a"));
+
     }
 }
 

--- a/src/test/resources/appmap_nested_shallow_test.yml
+++ b/src/test/resources/appmap_nested_shallow_test.yml
@@ -1,0 +1,12 @@
+name: appmap-nested-shallow-test
+packages:
+  - path: a
+  - path: b
+    shallow: true
+    exclude:
+      - b.a
+  - path: b.b
+    shallow: true
+  - path: b.c
+  - path: b.c.b
+    shallow: true


### PR DESCRIPTION
## Situation
While examining AppMaps with shallow-recorded spring framework packages, I've noticed that function calls of the Spring framework code frequently jump between its sub-packages, resulting in many recorded events sent between classes in the `org.springframework.web` package and its sub-packages despite the shallow recording configuration in `appmap.yml`. 

Such calls make the AppMaps large, make it difficult to spot the framework's calls to app code in the Trace and make the Dependency Map complex and hard to navigate. 

- Example: [AppMap recorded with `org.springframework.web` set to shallow, 245KB](https://app.land/scenarios/aabea295-ac76-4823-bdfb-5579fa8722b5)

Filtering the sub-packages out with `exclude` rules is not practical in my experience - it requires a complex `appmap.yml` configuration and many calls that are directly downstream from http server requests get filtered out as well, diminishing the benefits of shallow recording of application frameworks.

## The solution proposed in this PR
To eliminate these extraneous events, instead of directly comparing an event's class package with its upstream event's package in the shallow recording mode, packages of their nearest parents that are configured in `appmap.yml` are compared instead.  When the two consecutive events happen to live in the same "package tree" defined in `appmap.yml`, the downstream event is ignored.
- Example: [AppMap recorded from the same test with the proposed shallow logic, 116KB](https://app.land/scenarios/8f49e951-f98f-4579-b53f-3f938b390f58)

This  update also allows handpicked sub-packages to be "unshallowed" when called by/calling their parents or peers by explicitly listing them in `appmap.yml` and therefore placing them in a different "package tree".

## Example
If `appmap.yml` lists packages `a` and  `a.a` as shallow, the `a`->`a`, `a`->`a.b`, `a.c`->`a` or `a.a`->`a.a.a` events will all be ignored as they live in the same package trees, but `a`->`a.a` or `a.a.a`->`a` will not be ignored as the two events in each pair live in different package trees. Additional examples are available in the provided test.

## Other considerations
Because the lookup of the events' configured packages is more expensive than the original shallow logic, I've added a simple memoization - a map that maps package names to their configuration data.

## appmap.yml used for recording of the example AppMaps:
```yaml
name: spring-petclinic
packages:
- path: org.springframework.samples.petclinic
- path: org.springframework.web
  shallow: true
```




