### PR TITLE
Look for config in parent directories

### DIFF
--- a/src/main/java/com/appland/appmap/Agent.java
+++ b/src/main/java/com/appland/appmap/Agent.java
@@ -39,7 +39,7 @@ public class Agent {
 
     if (AppMapConfig.load(new File(Properties.ConfigFile)) == null) {
       Logger.printf("failed to load config %s\n", Properties.ConfigFile);
-      return;
+      System.exit(1);
     }
 
     if (Properties.RecordingAuto) {

--- a/src/main/java/com/appland/appmap/config/AppMapConfig.java
+++ b/src/main/java/com/appland/appmap/config/AppMapConfig.java
@@ -43,11 +43,15 @@ public class AppMapConfig {
 
     try {
       configFile = AppMapConfig.findConfig(configFile);
-      Logger.println(String.format("using config file -> %s", configFile.toPath().toAbsolutePath()));
+      Logger.println(String.format("using config file -> %s",
+                                   configFile.getAbsolutePath()));
       inputStream = new FileInputStream(configFile);
     } catch (FileNotFoundException e) {
-      Logger.println(String.format("error: file not found -> %s", configFile.getPath()));
-      Logger.error(String.format("error: file not found -> %s", configFile.getPath()));
+      String expectedConfig = configFile.getAbsolutePath();
+      Logger.println(String.format("error: file not found -> %s",
+                                   expectedConfig));
+      Logger.error(String.format("error: file not found -> %s",
+                                 expectedConfig));
       return null;
     }
 

--- a/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
+++ b/src/test/java/com/appland/appmap/config/AppMapConfigTest.java
@@ -7,9 +7,10 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class AppMapConfigTest {
 
@@ -32,10 +33,24 @@ public class AppMapConfigTest {
      */
     @Test
     public void load() {
-        AppMapConfig.load(new File("agent_conf.yml"));
+        // Trying to load appmap.yml in /tmp shouldn't work.
+        AppMapConfig.load(Paths.get(System.getProperty("java.io.tmpdir"), "appmap.yml").toFile());
         assertNotNull(errContent.toString());
         assertTrue(errContent.toString().contains("file not found"));
     }
+
+    // If a non-existent config file in a subdirectory is specified, the
+    // config file in the current directory should be used.
+    @Test
+    public void loadParent() {
+        File f = Paths.get("test", "appmap.yml").toFile();
+        assertFalse(f.exists());
+        AppMapConfig.load(f);
+        File expected = Paths.get("appmap.yml").toAbsolutePath().toFile();
+        assertTrue(expected.exists()); // sanity check
+        assertEquals(expected, AppMapConfig.get().configFile);
+    }
+
 }
 
 


### PR DESCRIPTION
If appmap.yml doesn't exist in the current directory, scan the parent directories for it.

Also, we now abort if we can't find a config file. Continuing with an empty config is likely to produce empty AppMaps and cause confusion.