### PR TITLE
test: Test access to Recorder.threadState

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
-  testImplementation "org.mockito:mockito-core:2.28.2"
+  testImplementation "org.mockito:mockito-core:3.+"
 }
 
 jar {

--- a/src/main/java/com/appland/appmap/record/Recorder.java
+++ b/src/main/java/com/appland/appmap/record/Recorder.java
@@ -9,6 +9,7 @@ import com.appland.appmap.util.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Stack;
@@ -258,6 +259,15 @@ public class Recorder {
     recording.moveTo(String.join(File.separator, new String[]{ Properties.getOutputDirectory().getPath(), fileName + ".appmap.json" }));
   }
 
+  // Mockito can't stub methods on the Collection<ThreadState>
+  // returned by values(), so return an iterator on it instead.
+  //
+  // And, make this method package-protected, because Mockito won't
+  // stub private methods.
+  /* private */ Iterator<ThreadState> getThreadStateIterator() {
+    return this.threadState.values().iterator();
+  }
+
   private ThreadState threadState() {
     ThreadState ts = threadState.get(Thread.currentThread().getId());
     if ( ts == null ) {
@@ -269,7 +279,7 @@ public class Recorder {
   // Finish serializing any remaining events. This is necessary because each event is "open"
   // until the next event on the same thread is received.
   private void flush() {
-    threadState.values().forEach((ts) -> {
+    getThreadStateIterator().forEachRemaining((ts) -> {
       if ( ts.lastEvent == null ) {
         return;
       }


### PR DESCRIPTION
Multiple threads can access Recorder.threadState. For example, one
thread may be adding a new event while another is calling checkpoint().
A previous commit allowed such concurrent access. This commit adds a
test for that change.