### PR TITLE
fix: Fix path and exclude item regexp

### DIFF
--- a/src/main/resources/config-schema.yml
+++ b/src/main/resources/config-schema.yml
@@ -18,11 +18,11 @@ properties:
           # Not too strict, but should eliminate at least some
           # incorrect names (e.g. filesystem paths instead of
           # packages)
-          pattern: ^[a-zA-Z0-9_.#]+$
+          pattern: ^[a-zA-Z0-9_.#$]+$
         shallow:
           type: boolean
         exclude:
           type: array
           items:
             type: string
-            pattern: ^[a-zA-Z0-9_.#]+$
+            pattern: ^[a-zA-Z0-9_.#$]+$


### PR DESCRIPTION
The path attribute of a package, as well as the items in an exclude
array, can have '$' in them. Fix the regexp in the config schema to
reflect this.

No tests here, it's `@appland/appmap` that actually uses the config schema.