### PR TITLE
feat: Record non-public methods

### DIFF
--- a/bin/test_run
+++ b/bin/test_run
@@ -5,3 +5,4 @@ export PATH="$BATS_DIR"/bin:$PATH
 ./test/petclinic/test
 ./test/http_client/test
 ./test/agent_cli/test
+./test/access/test

--- a/src/main/java/com/appland/appmap/config/Properties.java
+++ b/src/main/java/com/appland/appmap/config/Properties.java
@@ -33,8 +33,11 @@ public class Properties {
 
   public static final String[] DefaultRecords = new String[0];
   public static final String[] Records = resolveProperty(
-       "appmap.record", DefaultRecords);
+      "appmap.record", DefaultRecords);
 
+  public static final Boolean RecordPrivate = resolveProperty(
+      "appmap.record.private", Boolean::valueOf, false);
+      
   private static String resolveProperty(String propName, String defaultValue) {
     String value = defaultValue;
     try {

--- a/src/main/java/com/appland/appmap/process/conditions/ConfigCondition.java
+++ b/src/main/java/com/appland/appmap/process/conditions/ConfigCondition.java
@@ -1,10 +1,10 @@
 package com.appland.appmap.process.conditions;
 
 import com.appland.appmap.config.AppMapConfig;
+import com.appland.appmap.util.AppMapBehavior;
 import com.appland.appmap.util.StringUtil;
 import javassist.CtBehavior;
 
-import java.lang.reflect.Modifier;
 
 /**
  * ConfigCondition checks if the behavior should be hooked due to its inclusion in the
@@ -30,7 +30,7 @@ public abstract class ConfigCondition implements Condition {
       return false;
     }
 
-    if (!Modifier.isPublic(behavior.getModifiers())) {
+    if (!new AppMapBehavior(behavior).isRecordable()) {
       return false;
     }
 

--- a/src/main/java/com/appland/appmap/process/conditions/RecordCondition.java
+++ b/src/main/java/com/appland/appmap/process/conditions/RecordCondition.java
@@ -2,6 +2,7 @@ package com.appland.appmap.process.conditions;
 
 import com.appland.appmap.config.AppMapConfig;
 import com.appland.appmap.config.Properties;
+import com.appland.appmap.util.AppMapBehavior;
 import com.appland.appmap.util.StringUtil;
 import javassist.CtBehavior;
 
@@ -27,7 +28,7 @@ public abstract class RecordCondition implements Condition {
       return false;
     }
 
-    if (!Modifier.isPublic(behavior.getModifiers())) {
+    if (!new AppMapBehavior(behavior).isRecordable()) {
       return false;
     }
 

--- a/src/main/java/com/appland/appmap/util/AppMapBehavior.java
+++ b/src/main/java/com/appland/appmap/util/AppMapBehavior.java
@@ -1,0 +1,20 @@
+package com.appland.appmap.util;
+
+import java.lang.reflect.Modifier;
+
+import javassist.CtBehavior;
+
+
+import com.appland.appmap.config.Properties;
+
+public class AppMapBehavior {
+  private final CtBehavior behavior_;
+
+  public AppMapBehavior(CtBehavior behavior) {
+    behavior_ = behavior;
+  }
+
+  public Boolean isRecordable() {
+    return !Modifier.isPrivate(behavior_.getModifiers()) || Properties.RecordPrivate;
+  }
+}

--- a/src/test/java/com/appland/appmap/test/util/MyClass.java
+++ b/src/test/java/com/appland/appmap/test/util/MyClass.java
@@ -4,4 +4,17 @@ public class MyClass {
   public void myMethod() {
     // do nothing
   }
+
+  public void callNonPublic() {
+    myPackageMethod();
+    myPrivateMethod();
+  }
+
+  String myPackageMethod() {
+    return "package method";
+  }
+
+  private String myPrivateMethod() {
+    return "private method";
+  }
 }

--- a/test/access/.gitignore
+++ b/test/access/.gitignore
@@ -1,0 +1,1 @@
+RecordPackage.class

--- a/test/access/RecordPackage.java
+++ b/test/access/RecordPackage.java
@@ -1,0 +1,22 @@
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import com.appland.appmap.record.Recorder;
+import com.appland.appmap.record.Recording;
+
+import com.appland.appmap.test.util.MyClass;
+
+public class RecordPackage {
+  public static void main(String[] argv) {
+    final Recording recording = Recorder.getInstance().record(() -> {
+      new MyClass().callNonPublic();
+    });
+
+    try {
+      recording.readFully(true, new OutputStreamWriter(System.out));
+    } catch(IOException e) {
+      e.printStackTrace();
+    }
+
+  }
+}

--- a/test/access/access.bats
+++ b/test/access/access.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load '../../build/bats/bats-support/load'
+load '../../build/bats/bats-assert/load'
+load '../helper'
+
+appmap_jar="$(ls build/libs/appmap-[0-9]*.jar)"
+test_cp=test/access:build/classes/java/test
+
+setup() {
+  javac -cp "${appmap_jar}:${test_cp}" test/access/*.java
+}
+
+@test "testProtected" {
+  local cmd="java -javaagent:'${appmap_jar}' -cp '${test_cp}' RecordPackage"
+
+  # Exactly 4 events means that MyClass.myPrivateMethod was not recorded
+  eval "$cmd" | jq -e '.events | length | select(. == 4)'
+  eval "$cmd" | jq -e '.events[1] | select(.event == "call" and .method_id == "myPackageMethod")'
+}
+
+@test "testPrivate" {
+  local cmd="java -javaagent:${appmap_jar} -cp ${test_cp} -Dappmap.record.private=true RecordPackage"
+
+  # 6 events means that both myPackageMethod and myPrivateMethod were recorded
+  eval "$cmd" | jq -e '.events | length | select(. == 6)'
+  eval "$cmd" | jq -e '.events[3] | select(.event=="call" and .method_id=="myPrivateMethod")'
+}
+

--- a/test/access/test
+++ b/test/access/test
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bats --tap test/access/access.bats


### PR DESCRIPTION
By default, we'll now record methods with protected and package access.
Additionally, if the property appmap.record.private is true, we'll
capture private methods, too.