### PR TITLE
Add support for recording HTTP server requests to an Http Core server

### DIFF
--- a/src/main/java/com/appland/appmap/output/v1/Event.java
+++ b/src/main/java/com/appland/appmap/output/v1/Event.java
@@ -365,7 +365,7 @@ public class Event {
    * @return {@code this}
    * @see <a href="https://github.com/applandinc/appmap#http-server-response-attributes">GitHub: AppMap - HTTP server response attributes</a>
    */
-  public Event setHttpServerResponse(Integer status, String mimeType, Map<String, String> headers) {
+  public Event setHttpServerResponse(Integer status, Map<String, String> headers) {
     this.httpServerResponse = new HttpServerResponse()
         .setStatus(status)
         .setHeaders(headers);

--- a/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
+++ b/src/main/java/com/appland/appmap/process/hooks/HttpServerRequest.java
@@ -21,23 +21,38 @@ public class HttpServerRequest {
       return;
     }
 
-    event.setHttpServerRequest(req.getMethod(), req.getRequestURI(), req.getProtocol(), req.getHeaders());
+    recordHttpServerRequest(event,
+      req.getMethod(), req.getRequestURI(), req.getProtocol(), 
+      req.getHeaders(),
+      req.getParameterMap());
+  }
+
+  public static void recordHttpServerRequest(Event event, 
+    String method, String uri, String protocol, 
+    Map<String, String> headers,
+    Map<String, String[]> params)  {
+    event.setHttpServerRequest(method, uri, protocol, headers);
     event.setParameters(null);
     
-
-    for (Map.Entry<String, String[]> param : req.getParameterMap().entrySet()) {
-      final String[] values = param.getValue();
-      event.addMessageParam(param.getKey(), values.length > 0 ? values[0] : "");
+    if (params != null) {
+      for (Map.Entry<String, String[]> param : params.entrySet()) {
+        final String[] values = param.getValue();
+        event.addMessageParam(param.getKey(), values.length > 0 ? values[0] : "");
+      }
     }
-
     recorder.add(event);
   }
 
   private static void recordHttpServerResponse(Event event, HttpServletResponse res) {
-    event.setHttpServerResponse(res.getStatus(), res.getContentType(), res.getHeaders());
+    recordHttpServerResponse(event, res.getStatus(), res.getHeaders());
+  }
+
+  public static void recordHttpServerResponse(Event event, int status, Map<String,String> headers) {
+    event.setHttpServerResponse(status, headers);
     event.setParameters(null);
     recorder.add(event);
   }
+
 
   @ArgumentArray
   @ExcludeReceiver

--- a/src/main/java/com/appland/appmap/process/hooks/remoterecording/HttpCoreAsyncHooks.java
+++ b/src/main/java/com/appland/appmap/process/hooks/remoterecording/HttpCoreAsyncHooks.java
@@ -66,8 +66,8 @@ public class HttpCoreAsyncHooks {
     final HttpAsyncExchange httpexchange = (HttpAsyncExchange)args[1];
     final HttpResponse res = httpexchange.getResponse();
     final boolean handled = RemoteRecordingManager.service(new HttpCoreRequest(req, res));
-    httpexchange.submitResponse(new BasicAsyncResponseProducer(res));
     if (handled) {
+      httpexchange.submitResponse(new BasicAsyncResponseProducer(res));
       throw new ExitEarly();
     }
   }

--- a/src/main/java/com/appland/appmap/process/hooks/remoterecording/HttpCoreHooks.java
+++ b/src/main/java/com/appland/appmap/process/hooks/remoterecording/HttpCoreHooks.java
@@ -12,6 +12,7 @@ import com.appland.appmap.transform.annotations.ArgumentArray;
 import com.appland.appmap.transform.annotations.CallbackOn;
 import com.appland.appmap.transform.annotations.ExcludeReceiver;
 import com.appland.appmap.transform.annotations.HookClass;
+import com.appland.appmap.transform.annotations.ISystem;
 import com.appland.appmap.transform.annotations.MethodEvent;
 import com.appland.appmap.util.Logger;
 import com.appland.appmap.process.hooks.HttpServerRequest;
@@ -57,9 +58,8 @@ public class HttpCoreHooks {
 
   @ArgumentArray
   @ExcludeReceiver
-  @HookClass(value="org.apache.http.protocol.HttpRequestHandler", method="handle")
-  @CallbackOn(MethodEvent.METHOD_RETURN)
-  public static void postHandleSync(Event event, Object[] args)
+  @HookClass(value = "org.apache.http.protocol.HttpRequestHandler", method="handle", position = ISystem.HOOK_POSITION_LAST)
+  @CallbackOn(value = MethodEvent.METHOD_RETURN)
   public static void postHandleSync(Event event, Object ret, Object[] args)
     throws IOException, HttpException, ExitEarly {
     HttpResponse res = (HttpResponse) args[1];

--- a/src/main/java/com/appland/appmap/process/hooks/remoterecording/HttpCoreHooks.java
+++ b/src/main/java/com/appland/appmap/process/hooks/remoterecording/HttpCoreHooks.java
@@ -1,0 +1,69 @@
+package com.appland.appmap.process.hooks.remoterecording;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.appland.appmap.config.Properties;
+import com.appland.appmap.output.v1.Event;
+import com.appland.appmap.process.ExitEarly;
+import com.appland.appmap.record.Recording;
+import com.appland.appmap.transform.annotations.ArgumentArray;
+import com.appland.appmap.transform.annotations.CallbackOn;
+import com.appland.appmap.transform.annotations.ExcludeReceiver;
+import com.appland.appmap.transform.annotations.HookClass;
+import com.appland.appmap.transform.annotations.MethodEvent;
+import com.appland.appmap.util.Logger;
+import com.appland.appmap.process.hooks.HttpServerRequest;
+
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.RequestLine;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
+
+import org.apache.http.protocol.HttpContext;
+
+import org.apache.http.nio.protocol.BasicAsyncResponseProducer;
+import org.apache.http.nio.protocol.HttpAsyncExchange;
+
+public class HttpCoreHooks {
+  private static Boolean debug = Properties.DebugHttp;
+
+  private static Map<String, String> getHeaderMap(Header[] headers) {
+    HashMap<String, String> ret = new HashMap<String, String>();
+    for (Header h: headers) {
+      ret.put(h.getName(), h.getValue());
+    }
+
+    return ret;
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @HookClass(value="org.apache.http.protocol.HttpRequestHandler", method="handle")
+  public static void handleSync(Event event, Object[] args)
+    throws IOException, HttpException, ExitEarly {
+    HttpRequest req = (HttpRequest) args[0];
+    final RequestLine rl = req.getRequestLine();
+    HttpServerRequest.recordHttpServerRequest(event, 
+      rl.getMethod(), rl.getUri(), rl.getProtocolVersion().toString(),
+      getHeaderMap(req.getAllHeaders()),
+      null); // TODO: add params
+  }
+
+  @ArgumentArray
+  @ExcludeReceiver
+  @HookClass(value="org.apache.http.protocol.HttpRequestHandler", method="handle")
+  @CallbackOn(MethodEvent.METHOD_RETURN)
+  public static void postHandleSync(Event event, Object[] args)
+  public static void postHandleSync(Event event, Object ret, Object[] args)
+    throws IOException, HttpException, ExitEarly {
+    HttpResponse res = (HttpResponse) args[1];
+    HttpServerRequest.recordHttpServerResponse(event, res.getStatusLine().getStatusCode(), getHeaderMap(res.getAllHeaders()));
+  }
+
+}

--- a/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
+++ b/src/main/java/com/appland/appmap/transform/ClassFileTransformer.java
@@ -81,6 +81,7 @@ public class ClassFileTransformer implements java.lang.instrument.ClassFileTrans
 
     return Stream.of(matchingKeyedHooks, unkeyedHooks)
         .flatMap(Collection::stream)
+        .sorted(Comparator.comparingInt(Hook::getPosition))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/appland/appmap/transform/annotations/AnnotationUtil.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/AnnotationUtil.java
@@ -19,6 +19,19 @@ class AnnotationUtil {
   public static Object getValue(CtBehavior behavior,
                                 Class<?> annotationClass,
                                 Object defaultValue) {
+    return getValue(behavior, annotationClass, "value", defaultValue);
+  }
+
+  public static Integer getPosition(CtBehavior behavior,
+                                Class<?> annotationClass,
+                                Object defaultValue) {
+    return (Integer)getValue(behavior, annotationClass, "position", defaultValue);
+  }
+
+  private static Object getValue(CtBehavior behavior,
+                                Class<?> annotationClass,
+                                String annotationName,
+                                Object defaultValue) {
     try {
       Object annotation = behavior.getAnnotation(annotationClass);
       if (annotation == null) {
@@ -29,7 +42,7 @@ class AnnotationUtil {
         return defaultValue;
       }
 
-      Method valueMethod = annotationClass.getMethod("value");
+      Method valueMethod = annotationClass.getMethod(annotationName);
       if (valueMethod == null) {
         return defaultValue;
       }

--- a/src/main/java/com/appland/appmap/transform/annotations/BaseSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/BaseSystem.java
@@ -26,6 +26,10 @@ public abstract class BaseSystem implements ISystem {
     return this.hookBehavior;
   }
 
+  public Integer getHookPosition() {
+    return ISystem.HOOK_POSITION_DEFAULT;
+  }
+
   public Integer getParameterPriority() {
     return Integer.MAX_VALUE;
   }

--- a/src/main/java/com/appland/appmap/transform/annotations/Hook.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/Hook.java
@@ -299,4 +299,8 @@ public class Hook {
     }
     return null;
   }
+
+  public Integer getPosition() {
+    return sourceSystem.getHookPosition();
+  }
 }

--- a/src/main/java/com/appland/appmap/transform/annotations/HookClass.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookClass.java
@@ -24,4 +24,6 @@ public @interface HookClass {
    * @return A method name to apply this hook to.
    */
   public String method() default "";
+
+  public int position() default ISystem.HOOK_POSITION_DEFAULT;
 }

--- a/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/HookClassSystem.java
@@ -9,9 +9,11 @@ public class HookClassSystem extends SourceMethodSystem {
   private String targetClass = null;
   private String targetMethod = null;
   private Boolean ignoresChildren = IGNORE_CHILDREN_DEFAULT;
+  private final Integer position;
 
-  private HookClassSystem(CtBehavior behavior) {
+  private HookClassSystem(CtBehavior behavior, int position) {
     super(behavior);
+    this.position = position;
   }
 
   /**
@@ -38,7 +40,8 @@ public class HookClassSystem extends SourceMethodSystem {
           IgnoreChildren.class,
           IGNORE_CHILDREN_DEFAULT);
 
-      HookClassSystem system = new HookClassSystem(behavior);
+      Integer position = AnnotationUtil.getPosition(behavior, HookClass.class, ISystem.HOOK_POSITION_DEFAULT);
+      HookClassSystem system = new HookClassSystem(behavior, position);
       system.ignoresChildren = ignoresChildren;
       system.targetClass = hookClass.value();
       system.targetMethod = hookClass.method() == null || hookClass.method().isEmpty() 
@@ -72,5 +75,10 @@ public class HookClassSystem extends SourceMethodSystem {
   @Override
   public String getKey() {
     return this.targetMethod;
+  }
+
+  @Override
+  public Integer getHookPosition() {
+    return position;
   }
 }

--- a/src/main/java/com/appland/appmap/transform/annotations/ISystem.java
+++ b/src/main/java/com/appland/appmap/transform/annotations/ISystem.java
@@ -15,6 +15,10 @@ import javassist.CtBehavior;
  * @see ArgumentArray
  */
 public interface ISystem {
+  int HOOK_POSITION_FIRST = -1;
+  int HOOK_POSITION_DEFAULT = 0;
+  int HOOK_POSITION_LAST = 1;
+
   public static ISystem from(CtBehavior behavior) {
     return null;
   }
@@ -24,6 +28,8 @@ public interface ISystem {
   public void mutateStaticParameters(CtBehavior behavior, Parameters params);
 
   public void mutateRuntimeParameters(HookBinding binding, Parameters runtimeParameters);
+
+  public Integer getHookPosition();
 
   public Integer getParameterPriority();
 

--- a/test/httpcore/appmap.yml
+++ b/test/httpcore/appmap.yml
@@ -1,4 +1,4 @@
 name: httpcore
 packages:
-- path: org.apache.http.nio.protocol.HttpAsyncService#responseReady
+- path: org.apache.http.examples.nio
 

--- a/test/httpcore/build.gradle
+++ b/test/httpcore/build.gradle
@@ -27,11 +27,12 @@ dependencies {
 }
 
 application {
-  mainClass = 'org.apache.http.examples.nio.NHttpReverseProxy'
+  mainClass = 'org.apache.http.examples.nio.HelloWorldServer'
   applicationDefaultJvmArgs = [
     "-javaagent:${appmapJar}", 
     "-Dappmap.config.file=appmap.yml", 
     "-Dappmap.debug=true", 
-    "-Dappmap.debug.file=../../build/logs/httpcore-appmap.log"]
+    "-Dappmap.debug.file=../../build/logs/httpcore-appmap.log"
+  ]
 
 }

--- a/test/httpcore/httpcore.bats
+++ b/test/httpcore/httpcore.bats
@@ -75,6 +75,10 @@ load '../helper'
   # Sanity check the events and classmap
   assert_json_eq '.events | length' 6
 
+  # Make sure the return from the request handler and the http_server_response are ordered properly
+  assert_json_eq '.events[4].parent_id' 47
+  assert_json_eq '.events[5].event' return
+  assert_json_eq '.events[5].http_server_response.status' 200
   
   assert_json_eq '.classMap | length' 1
   assert_json_eq '[.classMap[0] | recurse | .name?] | join(".")' 'org.apache.http.examples.nio.HelloWorldServer$HelloWorldHandler.handle.sayHello'

--- a/test/httpcore/httpcore.bats
+++ b/test/httpcore/httpcore.bats
@@ -68,13 +68,14 @@ load '../helper'
 @test "expected appmap captured" {
   start_recording
   
-  _curl -XGET "${WS_URL}/vets"
+  _curl -XGET "${WS_URL}"
   
   stop_recording
 
   # Sanity check the events and classmap
-  assert_json_eq '.events | length' 8
+  assert_json_eq '.events | length' 6
 
+  
   assert_json_eq '.classMap | length' 1
-  assert_json_eq '[.classMap[0] | recurse | .name?] | join(".")' org.apache.http.nio.protocol.HttpAsyncService.responseReady
+  assert_json_eq '[.classMap[0] | recurse | .name?] | join(".")' 'org.apache.http.examples.nio.HelloWorldServer$HelloWorldHandler.handle.sayHello'
 }

--- a/test/httpcore/src/test/java/org/apache/http/examples/nio/HelloWorldServer.java
+++ b/test/httpcore/src/test/java/org/apache/http/examples/nio/HelloWorldServer.java
@@ -1,0 +1,63 @@
+package org.apache.http.examples.nio;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.entity.StringEntity;
+import org.apache.http.ExceptionLogger;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.impl.nio.bootstrap.HttpServer;
+import org.apache.http.impl.nio.bootstrap.ServerBootstrap;
+import org.apache.http.nio.protocol.BasicAsyncRequestHandler;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+
+public class HelloWorldServer {
+  static class HelloWorldHandler implements HttpRequestHandler {
+    String sayHello() { 
+      return "<body><html><h1>Hello World!</h1></html></body>";
+    }
+
+    public void handle(
+            final HttpRequest request,
+            final HttpResponse response,
+            final HttpContext context) throws HttpException, IOException {
+        response.setEntity(new StringEntity(sayHello()));
+        response.setStatusCode(200);
+    }
+  }
+
+  public HttpServer run(int port) throws IOException, InterruptedException {
+    final HttpServer server = ServerBootstrap.bootstrap()
+      .setListenerPort(port)
+      .setServerInfo("HelloWorld/1.1")
+      .setExceptionLogger(ExceptionLogger.STD_ERR)
+      .registerHandler("*", new BasicAsyncRequestHandler(new HelloWorldHandler()))
+      .create();
+
+      server.start();
+      server.awaitTermination(Long.MAX_VALUE, TimeUnit.DAYS);
+
+      return server;
+  }
+
+  public static void main(String[] argv) {
+    final int port = Integer.parseInt(argv[0]);
+
+    try {
+      final HttpServer server = new HelloWorldServer().run(port);
+
+      Runtime.getRuntime().addShutdownHook(new Thread() {
+          @Override
+          public void run() {
+              server.shutdown(5, TimeUnit.SECONDS);
+          }
+      });
+    } catch (Exception e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+}

--- a/test/httpcore/test
+++ b/test/httpcore/test
@@ -4,37 +4,14 @@ set -ax
 mkdir -p build/log
 
 LOG=$PWD/build/log/httpcore.log
-PC_LOG=$PWD/build/log/petclinic.log
-PETCLINIC_URL="http://localhost:8080"
-PROXY_PORT=9090
-WS_URL="http://localhost:${PROXY_PORT}"
+SERVER_PORT=9090
+WS_URL="http://localhost:${SERVER_PORT}"
 
-start_petclinic() {
-  pushd build/fixtures/spring-petclinic
-
-  ./mvnw spring-boot:run &> $PC_LOG &
-  PC_PID=$!
-
-  while [ -z "$(curl -sI $PETCLINIC_URL | grep 'HTTP/1.1 200')" ] ; do
-    if ! kill -0 "${PC_PID}" 2> /dev/null; then
-      printf '. failed!\n\nprocess exited unexpectedly:\n' 1>&2
-      cat $LOG
-      exit 1
-    fi
-
-    printf '.' 1>&2
-    sleep 1
-  done
-  printf ' ok\n\n' 1>&2
-  popd
-}
-start_petclinic
-
-start_revproxy() {
+start_server() {
   pushd test/httpcore
     
   printf 'getting set up' 1>&2
-  gradle run --args "${PETCLINIC_URL} ${PROXY_PORT}"   &> $LOG &
+  gradle run --args "${SERVER_PORT}"   &> $LOG &
 
   JVM_PID=$!
   while [ -z "$(curl -sI ${WS_URL} | grep 'HTTP/1.1 200')" ]; do
@@ -50,7 +27,7 @@ start_revproxy() {
   printf ' ok\n\n' 1>&2
   popd
 }
-start_revproxy
+start_server
 
 run_bats() {
   bats --tap test/httpcore/httpcore.bats > build/log/bats-httpcore.log 2>&1


### PR DESCRIPTION
These changes add support for capturing `http_server_request` and `http_server_response` events made to an Http Core server.

Http Core doesn't have a mechanism analogous to servlet filters. We're hooking the `handle` method in any class that implements `HttpRequestHandler` (e.g. https://github.com/applandinc/appmap-java/compare/core-server-request_20220217?expand=1#diff-52444c960044bb2cfe82e757cfa55ea0f9a414a6cede6d255ec32275ecc0f3e0R23) to generate `http_request_*` events. It's likely that this method will also be hooked to generate method `call` and `return` events. To ensure that all these events get added correctly, I needed to add a mechanism to control the order of hook application (see d111e0a).