### PR TITLE
fix: Don't call mocked java.sql methods

### DIFF
--- a/agent/src/main/java/com/appland/appmap/process/hooks/SqlQuery.java
+++ b/agent/src/main/java/com/appland/appmap/process/hooks/SqlQuery.java
@@ -9,6 +9,7 @@ import com.appland.appmap.transform.annotations.Unique;
 import com.appland.appmap.util.Logger;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -29,10 +30,23 @@ public class SqlQuery {
     recorder.add(event);
   }
 
+  private static boolean isMock(Object o) {
+    return o.getClass().getPackage().getName().startsWith("org.mockito");
+  }
+
   private static String getDbName(Connection c) {
     String dbname = "";
+    if (c == null) {
+      return dbname;
+    }
+
     try {
-      dbname = c.getMetaData().getDatabaseProductName();
+      DatabaseMetaData metadata;
+      if (isMock(c) || isMock(metadata = c.getMetaData())) {
+        return "[mocked]";
+      }
+
+      dbname = metadata.getDatabaseProductName();
     }
     catch (SQLException e) {
       Logger.println("WARNING, failed to get database name");
@@ -43,7 +57,15 @@ public class SqlQuery {
 
   private static String getDbName(Statement s) {
     String dbname = "";
+    if (s == null) {
+      return dbname;
+    }
+
     try {
+      if(isMock(s)) {
+        return "[mocked]";
+      }
+
       dbname = getDbName(s.getConnection());
     }
     catch (SQLException e) {

--- a/agent/src/test/java/com/appland/appmap/integration/MockerTest.java
+++ b/agent/src/test/java/com/appland/appmap/integration/MockerTest.java
@@ -1,0 +1,39 @@
+package com.appland.appmap.integration;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+// These tests are run with recording enabled. Getting to the end of the test
+// shows that recording is working correctly.
+public class MockerTest {
+  @Test
+  public void testMockedStatement() {
+    final Statement s = mock(Statement.class);
+    try {
+      s.execute("select 1;");
+    }
+    catch (SQLException e) {
+      e.printStackTrace();
+    }
+
+    assert(true);
+  }
+
+  @Test
+  public void testMockedConnection() {
+    final Connection c = mock(Connection.class);
+    try {
+      final String s = c.nativeSQL("select 1");
+    }
+    catch (SQLException e) {
+      e.printStackTrace();
+    }
+
+    assert(true);
+  }
+}


### PR DESCRIPTION
When recording a SQL query, make sure we don't call methods of objects
that have been mocked. Doing so is likely to break the user's tests.

Fixes #129.

This currently only checks for Mockito. In follow-on work, I'm planning to make the choice of mocking frameworks configurable in `appmap.yml`.