### PR TITLE
Fix NPE that happens when examining a class in the unnamed package

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -59,7 +59,10 @@ dependencies {
   // com.appland.appmap.annotation.
   // implementation project(':annotation')
 
-  testImplementation 'junit:junit:4.12'
+  testImplementation platform('org.junit:junit-bom:5.8.2')
+  testImplementation 'org.junit.jupiter:junit-jupiter'
+  testImplementation 'org.junit.vintage:junit-vintage-engine'
+  
   testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
   testImplementation "org.mockito:mockito-core:3.+"
 }
@@ -88,8 +91,6 @@ shadowJar {
     exclude(dependency('org.apache.httpcomponents:.*:.*'))
  }
 }
-
-
 
 sourceSets {
   main {
@@ -124,7 +125,7 @@ task integrationTest(type: Test) {
 }
 
 test {
-  useJUnit()
+  useJUnitPlatform()
   dependsOn shadowJar
   dependsOn cleanTest
   exclude 'com/appland/appmap/integration/**'
@@ -162,6 +163,7 @@ task sourcesJar(type: Jar) {
 javadoc {
   exclude 'com/appland/**'
 }
+
 task mockJavadocJar(type: Jar) {
   classifier = 'javadoc'
   from javadoc.destinationDir
@@ -235,3 +237,5 @@ if (project.hasProperty("signingKey")) {
     sign publishing.publications.appMapAgent
   }
 }
+
+tasks.publishToMavenLocal.dependsOn(check, integrationTest)

--- a/agent/src/main/java/com/appland/appmap/util/FullyQualifiedName.java
+++ b/agent/src/main/java/com/appland/appmap/util/FullyQualifiedName.java
@@ -11,7 +11,7 @@ public class FullyQualifiedName {
 
   public FullyQualifiedName(String packageName, String className, boolean isStatic,
       String methodName) {
-    this.packageName = packageName;
+    this.packageName = packageName != null? packageName : "";
     this.className = className;
     this.isStatic = isStatic;
     this.methodName = methodName;

--- a/agent/src/test/java/com/appland/appmap/config/AppMapPackageTest.java
+++ b/agent/src/test/java/com/appland/appmap/config/AppMapPackageTest.java
@@ -53,7 +53,7 @@ public class AppMapPackageTest {
 
   @Nested
   class LabelConfigTests {
-    private AppMapPackage.LabelConfig lc;
+    AppMapPackage.LabelConfig lc;
     @Nested
     class WithFullSpec {
       @BeforeEach
@@ -81,7 +81,7 @@ public class AppMapPackageTest {
     @Test
     void testMissingLabels() throws Exception {
       lc = loadYaml(METHOD_ONLY_SPEC, AppMapPackage.LabelConfig.class);
-      assertNull(lc.labels);
+      assertNull(lc.getLabels());
     }
 
     @Test

--- a/agent/src/test/java/com/appland/appmap/config/AppMapPackageTest.java
+++ b/agent/src/test/java/com/appland/appmap/config/AppMapPackageTest.java
@@ -1,94 +1,106 @@
 package com.appland.appmap.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
-class Tests {
-  static class Fixtures {
-    //@formatter:off
-    final static String[] LABEL_SPEC = {
-      "---",
-      "class: (Foo|Bar)", 
-      "name: (foo|bar)",
-      "labels: [foo]"
-    };
- 
-    final static String[] PACKAGE_CONFIG = {
-      "---",
-      "path: com.example",
-      "exclude: [com.example.Spam.ham]",
-      "methods:",
-      "- class: (Foo|Bar)",
-      "  name: (foo|bar)",
-      "  labels: [foo]"
-    };
-    //@formatter:on
-  }
-
-  public static class LabelConfigTests {
-    private AppMapPackage.LabelConfig lc;
-
-    @Before
-    public void load() {
-      final String input = String.join("\n", Fixtures.LABEL_SPEC);
-
-      ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-      try {
-        lc = mapper.readValue(input, AppMapPackage.LabelConfig.class);
-        assertEquals("foo", lc.getLabels()[0]);
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(e.getMessage());
-      }
-    }
-
-    @Test
-    public void testMatches() {
-      assertTrue(lc.matches("Foo", "bar"));
-    }
-
-    @Test
-    public void testMatchesWholeClass() {
-      assertFalse(lc.matches("Foo$Foo1", "bar"));
-    }
-
-    @Test
-    public void testMatchesWholeName() {
-      assertFalse(lc.matches("Foo", "bar!"));
-    }
-  }
-
-  public static class PackageTests {
-    @Test
-    public void testLoadConfig() {
-      final String input = String.join("\n", Fixtures.PACKAGE_CONFIG);
-      ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-      try {
-        final AppMapPackage appMapPackage = mapper.readValue(input, AppMapPackage.class);
-        assertEquals("com.example", appMapPackage.path);
-        assertNotNull(appMapPackage.methods);
-
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(e.getMessage());
-      }
-    }
-  }
-}
-
-
-@RunWith(Suite.class)
-@Suite.SuiteClasses({Tests.LabelConfigTests.class, Tests.PackageTests.class})
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 public class AppMapPackageTest {
-}
+  <T> T loadYaml(String[] yaml, Class<T> c) throws Exception {
+    final String input = String.join("\n", yaml);
 
+    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    return (T) mapper.readValue(input, c);
+  }
+
+  //@formatter:off
+  final static String[] LABEL_SPEC = {
+    "---",
+    "class: (Foo|Bar)", 
+    "name: (foo|bar)",
+    "labels: [foo]"
+  };
+
+  final static String[] METHOD_ONLY_SPEC = {
+    "---",
+    "class: (Foo|Bar)", 
+    "name: (foo|bar)",
+  };
+  final static String[] BROKEN_REGEX_SPEC = {
+    "---",
+    "class: (Foo|Bar", 
+    "name: (foo|bar)",
+  };
+
+  final static String[] PACKAGE_CONFIG = {
+    "---",
+    "path: com.example",
+    "exclude: [com.example.Spam.ham]",
+    "methods:",
+    "- class: (Foo|Bar)",
+    "  name: (foo|bar)",
+    "  labels: [foo]"
+  };
+  //@formatter:on
+
+  @Nested
+  class LabelConfigTests {
+    private AppMapPackage.LabelConfig lc;
+    @Nested
+    class WithFullSpec {
+      @BeforeEach
+      public void load() throws Exception {
+        lc = loadYaml(LABEL_SPEC, AppMapPackage.LabelConfig.class);
+        assertEquals("foo", lc.getLabels()[0]);
+      }
+
+      @Test
+      public void testMatches() {
+        assertTrue(lc.matches("Foo", "bar"));
+      }
+
+      @Test
+      public void testMatchesWholeClass() {
+        assertFalse(lc.matches("Foo$Foo1", "bar"));
+      }
+
+      @Test
+      public void testMatchesWholeName() {
+        assertFalse(lc.matches("Foo", "bar!"));
+      }
+    }
+
+    @Test
+    void testMissingLabels() throws Exception {
+      lc = loadYaml(METHOD_ONLY_SPEC, AppMapPackage.LabelConfig.class);
+      assertNull(lc.labels);
+    }
+
+    @Test
+    void testBrokenRegex() throws Exception {
+      assertThrows(JsonProcessingException.class,
+          () -> loadYaml(BROKEN_REGEX_SPEC, AppMapPackage.LabelConfig.class));
+    }
+
+  }
+
+  @Nested
+  class PackageTests {
+    AppMapPackage appMapPackage;
+
+    @Test
+    public void testLoadConfig() throws Exception {
+      appMapPackage = loadYaml(PACKAGE_CONFIG, AppMapPackage.class);
+      assertEquals("com.example", appMapPackage.path);
+      assertNotNull(appMapPackage.methods);
+    }
+  }
+}

--- a/agent/src/test/java/com/appland/appmap/util/FullyQualifiedNameTest.java
+++ b/agent/src/test/java/com/appland/appmap/util/FullyQualifiedNameTest.java
@@ -1,0 +1,14 @@
+package com.appland.appmap.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+public class FullyQualifiedNameTest {
+  FullyQualifiedName fqn;
+
+  @Test
+  void testPackageNameIsNull() {
+    fqn = new FullyQualifiedName(null,"class",false,"method");
+    assertEquals("", fqn.packageName);
+  };
+}


### PR DESCRIPTION
A `CtBehavior` for a class in the unnamed package returns `null` for it's package name. This change handles that case in `FullyQualifiedName` by returning `""` instead.

Also, these changes switch to using JUnit 5 for new tests. Existing tests still use JUnit conventions (enabled by including `junit-vintage-engine`).